### PR TITLE
Add command line parsing to run benchmarks

### DIFF
--- a/utils/rand_array.h
+++ b/utils/rand_array.h
@@ -10,6 +10,7 @@
 template <typename T>
 static std::vector<T> get_uniform_rand_array(
         int64_t arrsize,
+        int seed = 42,
         T max = std::numeric_limits<T>::max(),
         T min = std::numeric_limits<T>::min(),
         typename std::enable_if<std::is_integral<T>::value>::type * = 0)
@@ -17,6 +18,7 @@ static std::vector<T> get_uniform_rand_array(
     std::vector<T> arr;
     std::random_device r;
     std::default_random_engine e1(r());
+    e1.seed(seed);
     std::uniform_int_distribution<T> uniform_dist(min, max);
     for (int64_t ii = 0; ii < arrsize; ++ii) {
         arr.emplace_back(uniform_dist(e1));
@@ -27,12 +29,14 @@ static std::vector<T> get_uniform_rand_array(
 template <typename T>
 static std::vector<T> get_uniform_rand_array(
         int64_t arrsize,
+        int seed = 42,
         T max = std::numeric_limits<T>::max(),
         T min = std::numeric_limits<T>::min(),
         typename std::enable_if<std::is_floating_point<T>::value>::type * = 0)
 {
     std::random_device rd;
     std::mt19937 gen(rd());
+    gen.seed(seed);
     std::uniform_real_distribution<> dis(min, max);
     std::vector<T> arr;
     for (int64_t ii = 0; ii < arrsize; ++ii) {


### PR DESCRIPTION
Add command line arguments to run benchmarks:

```
Usage:  benchexe options [ ... ]
  -h  --help                            Display this usage information.
  -d  --dtypesize <list dtypes>         List of dtype sizes in bytes to benchmark. Options: 2,4,8
  -a  --arraytype <array data types>    Types of data in random unsorted array. Options: uniform, reverse, ordered, limitedrange
  -s  --seed <random generator seed>    Seed for the random number generator as an int
```
