### PR TITLE
update meson.build to ensure AVX-512 FP16 can be compiled

### DIFF
--- a/benchmarks/meson.build
+++ b/benchmarks/meson.build
@@ -9,7 +9,7 @@ if cpp.has_argument('-march=icelake-client')
     )
 endif
 
-if cpp.has_argument('-march=sapphirerapids')
+if cancompilefp16
   libbench += static_library('bench_qsortfp16',
     files('bench_qsortfp16.cpp', ),
     dependencies: gbench_dep,

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,16 @@ utils = include_directories('utils')
 tests = include_directories('tests')
 gtest_dep = dependency('gtest_main', required : true)
 gbench_dep = dependency('benchmark', required : true)
+
+fp16code = '''#include<immintrin.h>
+int main() { 
+  __mm512h temp = _mm512_set1_ph(1.0f);
+  __mm512h var2 = _mm512_min_ph(temp, temp);
+  return 0;
+}
+'''
+cancompilefp16 = cpp.compiles(fp16code, args:'-march=sapphirerapids')
+
 subdir('utils')
 subdir('tests')
 subdir('benchmarks')
@@ -23,3 +33,11 @@ benchexe = executable('benchexe', 'benchmarks/main.cpp',
                       dependencies : [gbench_dep],
                       link_whole : [libbench, libcpuinfo],
                      )
+
+summary({
+  'Can compile AVX-512 FP16 ISA': cancompilefp16,
+  },
+  section: 'Configuration',
+  bool_yn: true
+  )
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,7 +18,7 @@ if cpp.has_argument('-march=icelake-client')
     )
 endif
 
-if cpp.has_argument('-march=sapphirerapids')
+if cancompilefp16
   libtests += static_library('tests_qsortfp16',
     files('test_qsortfp16.cpp', ),
     dependencies: gtest_dep,


### PR DESCRIPTION
Required to check availability of both compiler and assembler. 