### PR TITLE
Improve qsort

### DIFF
--- a/src/avx512-16bit-common.h
+++ b/src/avx512-16bit-common.h
@@ -290,10 +290,11 @@ qsort_16bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
 }
 
 template <typename vtype, typename type_t>
-static void
-qselect_16bit_(type_t *arr, int64_t pos,
-               int64_t left, int64_t right,
-               int64_t max_iters)
+static void qselect_16bit_(type_t *arr,
+                           int64_t pos,
+                           int64_t left,
+                           int64_t right,
+                           int64_t max_iters)
 {
     /*
      * Resort to std::sort if quicksort isnt making any progress

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -648,7 +648,7 @@ qsort_32bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     type_t pivot = get_pivot_32bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         qsort_32bit_<vtype>(arr, left, pivot_index - 1, max_iters - 1);

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -648,7 +648,7 @@ qsort_32bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     type_t pivot = get_pivot_32bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512_unrolled<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype,2>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         qsort_32bit_<vtype>(arr, left, pivot_index - 1, max_iters - 1);
@@ -680,7 +680,7 @@ qselect_32bit_(type_t *arr, int64_t pos,
     type_t pivot = get_pivot_32bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype,2>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         qselect_32bit_<vtype>(arr, pos, left, pivot_index - 1, max_iters - 1);

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -648,7 +648,7 @@ qsort_32bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     type_t pivot = get_pivot_32bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512_unrolled<vtype,2>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype, 2>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         qsort_32bit_<vtype>(arr, left, pivot_index - 1, max_iters - 1);
@@ -657,10 +657,11 @@ qsort_32bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
 }
 
 template <typename vtype, typename type_t>
-static void
-qselect_32bit_(type_t *arr, int64_t pos,
-               int64_t left, int64_t right,
-               int64_t max_iters)
+static void qselect_32bit_(type_t *arr,
+                           int64_t pos,
+                           int64_t left,
+                           int64_t right,
+                           int64_t max_iters)
 {
     /*
      * Resort to std::sort if quicksort isnt making any progress
@@ -680,7 +681,7 @@ qselect_32bit_(type_t *arr, int64_t pos,
     type_t pivot = get_pivot_32bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512_unrolled<vtype,2>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype, 2>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         qselect_32bit_<vtype>(arr, pos, left, pivot_index - 1, max_iters - 1);

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -390,24 +390,20 @@ X86_SIMD_SORT_INLINE type_t get_pivot_64bit(type_t *arr,
                                             const int64_t left,
                                             const int64_t right)
 {
-    // median of 8x8 elements
+    // median of 8
     int64_t size = (right - left) / 8;
     using zmm_t = typename vtype::zmm_t;
-    zmm_t v[8];
-    for (int64_t ii = 0; ii < 8; ++ii) {
-        v[ii] = vtype::loadu(arr + left + ii*size);
-    }
-    COEX<vtype>(v[0], v[1]); COEX<vtype>(v[2], v[3]); /* step 1 */
-    COEX<vtype>(v[4], v[5]); COEX<vtype>(v[6], v[7]);
-    COEX<vtype>(v[0], v[2]); COEX<vtype>(v[1], v[3]); /* step 2 */
-    COEX<vtype>(v[4], v[6]); COEX<vtype>(v[5], v[7]);
-    COEX<vtype>(v[0], v[4]); COEX<vtype>(v[1], v[2]); /* step 3 */
-    COEX<vtype>(v[5], v[6]); COEX<vtype>(v[3], v[7]);
-    COEX<vtype>(v[1], v[5]); COEX<vtype>(v[2], v[6]); /* step 4 */
-    COEX<vtype>(v[3], v[5]); COEX<vtype>(v[2], v[4]); /* step 5 */
-    COEX<vtype>(v[3], v[4]);                   /* step 6 */
+    __m512i rand_index = _mm512_set_epi64(left + size,
+                                          left + 2 * size,
+                                          left + 3 * size,
+                                          left + 4 * size,
+                                          left + 5 * size,
+                                          left + 6 * size,
+                                          left + 7 * size,
+                                          left + 8 * size);
+    zmm_t rand_vec = vtype::template i64gather<sizeof(type_t)>(rand_index, arr);
     // pivot will never be a nan, since there are no nan's!
-    zmm_t sort = sort_zmm_64bit<vtype>(v[3]);
+    zmm_t sort = sort_zmm_64bit<vtype>(rand_vec);
     return ((type_t *)&sort)[4];
 }
 

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -739,7 +739,7 @@ qsort_64bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     type_t pivot = get_pivot_64bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         qsort_64bit_<vtype>(arr, left, pivot_index - 1, max_iters - 1);

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -580,7 +580,7 @@ X86_SIMD_SORT_INLINE void sort_256_64bit(type_t *arr, int32_t N)
         uint64_t combined_mask;
         if (N < 192) {
             combined_mask = (0x1ull << (N - 128)) - 0x1ull;
-            load_mask1 = (combined_mask) & 0xFF;
+            load_mask1 = (combined_mask)&0xFF;
             load_mask2 = (combined_mask >> 8) & 0xFF;
             load_mask3 = (combined_mask >> 16) & 0xFF;
             load_mask4 = (combined_mask >> 24) & 0xFF;
@@ -588,14 +588,18 @@ X86_SIMD_SORT_INLINE void sort_256_64bit(type_t *arr, int32_t N)
             load_mask6 = (combined_mask >> 40) & 0xFF;
             load_mask7 = (combined_mask >> 48) & 0xFF;
             load_mask8 = (combined_mask >> 56) & 0xFF;
-            load_mask9 = 0x00; load_mask10 = 0x0;
-            load_mask11 = 0x00; load_mask12 = 0x00;
-            load_mask13 = 0x00; load_mask14 = 0x00;
-            load_mask15 = 0x00; load_mask16 = 0x00;
+            load_mask9 = 0x00;
+            load_mask10 = 0x0;
+            load_mask11 = 0x00;
+            load_mask12 = 0x00;
+            load_mask13 = 0x00;
+            load_mask14 = 0x00;
+            load_mask15 = 0x00;
+            load_mask16 = 0x00;
         }
         else {
             combined_mask = (0x1ull << (N - 192)) - 0x1ull;
-            load_mask9  = (combined_mask) & 0xFF;
+            load_mask9 = (combined_mask)&0xFF;
             load_mask10 = (combined_mask >> 8) & 0xFF;
             load_mask11 = (combined_mask >> 16) & 0xFF;
             load_mask12 = (combined_mask >> 24) & 0xFF;
@@ -714,7 +718,6 @@ X86_SIMD_SORT_INLINE void sort_256_64bit(type_t *arr, int32_t N)
         vtype::mask_storeu(arr + 240, load_mask15, zmm[30]);
         vtype::mask_storeu(arr + 248, load_mask16, zmm[31]);
     }
-
 }
 
 template <typename vtype, typename type_t>

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -742,7 +742,7 @@ qsort_64bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     type_t pivot = get_pivot_64bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512_unrolled<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype, 8>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         qsort_64bit_<vtype>(arr, left, pivot_index - 1, max_iters - 1);
@@ -774,7 +774,7 @@ qselect_64bit_(type_t *arr, int64_t pos,
     type_t pivot = get_pivot_64bit<vtype>(arr, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    int64_t pivot_index = partition_avx512<vtype>(
+    int64_t pivot_index = partition_avx512_unrolled<vtype, 8>(
             arr, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         qselect_64bit_<vtype>(arr, pos, left, pivot_index - 1, max_iters - 1);

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -751,10 +751,11 @@ qsort_64bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
 }
 
 template <typename vtype, typename type_t>
-static void
-qselect_64bit_(type_t *arr, int64_t pos,
-               int64_t left, int64_t right,
-               int64_t max_iters)
+static void qselect_64bit_(type_t *arr,
+                           int64_t pos,
+                           int64_t left,
+                           int64_t right,
+                           int64_t max_iters)
 {
     /*
      * Resort to std::sort if quicksort isnt making any progress

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -172,6 +172,161 @@ X86_SIMD_SORT_INLINE void bitonic_merge_sixteen_zmm_64bit(zmm_t *zmm)
     zmm[15] = bitonic_merge_zmm_64bit<vtype>(zmm_t16);
 }
 
+template <typename vtype, typename zmm_t = typename vtype::zmm_t>
+X86_SIMD_SORT_INLINE void bitonic_merge_32_zmm_64bit(zmm_t *zmm)
+{
+    const __m512i rev_index = _mm512_set_epi64(NETWORK_64BIT_2);
+    zmm_t zmm16r = vtype::permutexvar(rev_index, zmm[16]);
+    zmm_t zmm17r = vtype::permutexvar(rev_index, zmm[17]);
+    zmm_t zmm18r = vtype::permutexvar(rev_index, zmm[18]);
+    zmm_t zmm19r = vtype::permutexvar(rev_index, zmm[19]);
+    zmm_t zmm20r = vtype::permutexvar(rev_index, zmm[20]);
+    zmm_t zmm21r = vtype::permutexvar(rev_index, zmm[21]);
+    zmm_t zmm22r = vtype::permutexvar(rev_index, zmm[22]);
+    zmm_t zmm23r = vtype::permutexvar(rev_index, zmm[23]);
+    zmm_t zmm24r = vtype::permutexvar(rev_index, zmm[24]);
+    zmm_t zmm25r = vtype::permutexvar(rev_index, zmm[25]);
+    zmm_t zmm26r = vtype::permutexvar(rev_index, zmm[26]);
+    zmm_t zmm27r = vtype::permutexvar(rev_index, zmm[27]);
+    zmm_t zmm28r = vtype::permutexvar(rev_index, zmm[28]);
+    zmm_t zmm29r = vtype::permutexvar(rev_index, zmm[29]);
+    zmm_t zmm30r = vtype::permutexvar(rev_index, zmm[30]);
+    zmm_t zmm31r = vtype::permutexvar(rev_index, zmm[31]);
+    zmm_t zmm_t1 = vtype::min(zmm[0], zmm31r);
+    zmm_t zmm_t2 = vtype::min(zmm[1], zmm30r);
+    zmm_t zmm_t3 = vtype::min(zmm[2], zmm29r);
+    zmm_t zmm_t4 = vtype::min(zmm[3], zmm28r);
+    zmm_t zmm_t5 = vtype::min(zmm[4], zmm27r);
+    zmm_t zmm_t6 = vtype::min(zmm[5], zmm26r);
+    zmm_t zmm_t7 = vtype::min(zmm[6], zmm25r);
+    zmm_t zmm_t8 = vtype::min(zmm[7], zmm24r);
+    zmm_t zmm_t9 = vtype::min(zmm[8], zmm23r);
+    zmm_t zmm_t10 = vtype::min(zmm[9], zmm22r);
+    zmm_t zmm_t11 = vtype::min(zmm[10], zmm21r);
+    zmm_t zmm_t12 = vtype::min(zmm[11], zmm20r);
+    zmm_t zmm_t13 = vtype::min(zmm[12], zmm19r);
+    zmm_t zmm_t14 = vtype::min(zmm[13], zmm18r);
+    zmm_t zmm_t15 = vtype::min(zmm[14], zmm17r);
+    zmm_t zmm_t16 = vtype::min(zmm[15], zmm16r);
+    zmm_t zmm_t17 = vtype::permutexvar(rev_index, vtype::max(zmm[15], zmm16r));
+    zmm_t zmm_t18 = vtype::permutexvar(rev_index, vtype::max(zmm[14], zmm17r));
+    zmm_t zmm_t19 = vtype::permutexvar(rev_index, vtype::max(zmm[13], zmm18r));
+    zmm_t zmm_t20 = vtype::permutexvar(rev_index, vtype::max(zmm[12], zmm19r));
+    zmm_t zmm_t21 = vtype::permutexvar(rev_index, vtype::max(zmm[11], zmm20r));
+    zmm_t zmm_t22 = vtype::permutexvar(rev_index, vtype::max(zmm[10], zmm21r));
+    zmm_t zmm_t23 = vtype::permutexvar(rev_index, vtype::max(zmm[9], zmm22r));
+    zmm_t zmm_t24 = vtype::permutexvar(rev_index, vtype::max(zmm[8], zmm23r));
+    zmm_t zmm_t25 = vtype::permutexvar(rev_index, vtype::max(zmm[7], zmm24r));
+    zmm_t zmm_t26 = vtype::permutexvar(rev_index, vtype::max(zmm[6], zmm25r));
+    zmm_t zmm_t27 = vtype::permutexvar(rev_index, vtype::max(zmm[5], zmm26r));
+    zmm_t zmm_t28 = vtype::permutexvar(rev_index, vtype::max(zmm[4], zmm27r));
+    zmm_t zmm_t29 = vtype::permutexvar(rev_index, vtype::max(zmm[3], zmm28r));
+    zmm_t zmm_t30 = vtype::permutexvar(rev_index, vtype::max(zmm[2], zmm29r));
+    zmm_t zmm_t31 = vtype::permutexvar(rev_index, vtype::max(zmm[1], zmm30r));
+    zmm_t zmm_t32 = vtype::permutexvar(rev_index, vtype::max(zmm[0], zmm31r));
+    // Recusive half clear 16 zmm regs
+    COEX<vtype>(zmm_t1, zmm_t9);
+    COEX<vtype>(zmm_t2, zmm_t10);
+    COEX<vtype>(zmm_t3, zmm_t11);
+    COEX<vtype>(zmm_t4, zmm_t12);
+    COEX<vtype>(zmm_t5, zmm_t13);
+    COEX<vtype>(zmm_t6, zmm_t14);
+    COEX<vtype>(zmm_t7, zmm_t15);
+    COEX<vtype>(zmm_t8, zmm_t16);
+    COEX<vtype>(zmm_t17, zmm_t25);
+    COEX<vtype>(zmm_t18, zmm_t26);
+    COEX<vtype>(zmm_t19, zmm_t27);
+    COEX<vtype>(zmm_t20, zmm_t28);
+    COEX<vtype>(zmm_t21, zmm_t29);
+    COEX<vtype>(zmm_t22, zmm_t30);
+    COEX<vtype>(zmm_t23, zmm_t31);
+    COEX<vtype>(zmm_t24, zmm_t32);
+    //
+    COEX<vtype>(zmm_t1, zmm_t5);
+    COEX<vtype>(zmm_t2, zmm_t6);
+    COEX<vtype>(zmm_t3, zmm_t7);
+    COEX<vtype>(zmm_t4, zmm_t8);
+    COEX<vtype>(zmm_t9, zmm_t13);
+    COEX<vtype>(zmm_t10, zmm_t14);
+    COEX<vtype>(zmm_t11, zmm_t15);
+    COEX<vtype>(zmm_t12, zmm_t16);
+    COEX<vtype>(zmm_t17, zmm_t21);
+    COEX<vtype>(zmm_t18, zmm_t22);
+    COEX<vtype>(zmm_t19, zmm_t23);
+    COEX<vtype>(zmm_t20, zmm_t24);
+    COEX<vtype>(zmm_t25, zmm_t29);
+    COEX<vtype>(zmm_t26, zmm_t30);
+    COEX<vtype>(zmm_t27, zmm_t31);
+    COEX<vtype>(zmm_t28, zmm_t32);
+    //
+    COEX<vtype>(zmm_t1, zmm_t3);
+    COEX<vtype>(zmm_t2, zmm_t4);
+    COEX<vtype>(zmm_t5, zmm_t7);
+    COEX<vtype>(zmm_t6, zmm_t8);
+    COEX<vtype>(zmm_t9, zmm_t11);
+    COEX<vtype>(zmm_t10, zmm_t12);
+    COEX<vtype>(zmm_t13, zmm_t15);
+    COEX<vtype>(zmm_t14, zmm_t16);
+    COEX<vtype>(zmm_t17, zmm_t19);
+    COEX<vtype>(zmm_t18, zmm_t20);
+    COEX<vtype>(zmm_t21, zmm_t23);
+    COEX<vtype>(zmm_t22, zmm_t24);
+    COEX<vtype>(zmm_t25, zmm_t27);
+    COEX<vtype>(zmm_t26, zmm_t28);
+    COEX<vtype>(zmm_t29, zmm_t31);
+    COEX<vtype>(zmm_t30, zmm_t32);
+    //
+    COEX<vtype>(zmm_t1, zmm_t2);
+    COEX<vtype>(zmm_t3, zmm_t4);
+    COEX<vtype>(zmm_t5, zmm_t6);
+    COEX<vtype>(zmm_t7, zmm_t8);
+    COEX<vtype>(zmm_t9, zmm_t10);
+    COEX<vtype>(zmm_t11, zmm_t12);
+    COEX<vtype>(zmm_t13, zmm_t14);
+    COEX<vtype>(zmm_t15, zmm_t16);
+    COEX<vtype>(zmm_t17, zmm_t18);
+    COEX<vtype>(zmm_t19, zmm_t20);
+    COEX<vtype>(zmm_t21, zmm_t22);
+    COEX<vtype>(zmm_t23, zmm_t24);
+    COEX<vtype>(zmm_t25, zmm_t26);
+    COEX<vtype>(zmm_t27, zmm_t28);
+    COEX<vtype>(zmm_t29, zmm_t30);
+    COEX<vtype>(zmm_t31, zmm_t32);
+    //
+    zmm[0] = bitonic_merge_zmm_64bit<vtype>(zmm_t1);
+    zmm[1] = bitonic_merge_zmm_64bit<vtype>(zmm_t2);
+    zmm[2] = bitonic_merge_zmm_64bit<vtype>(zmm_t3);
+    zmm[3] = bitonic_merge_zmm_64bit<vtype>(zmm_t4);
+    zmm[4] = bitonic_merge_zmm_64bit<vtype>(zmm_t5);
+    zmm[5] = bitonic_merge_zmm_64bit<vtype>(zmm_t6);
+    zmm[6] = bitonic_merge_zmm_64bit<vtype>(zmm_t7);
+    zmm[7] = bitonic_merge_zmm_64bit<vtype>(zmm_t8);
+    zmm[8] = bitonic_merge_zmm_64bit<vtype>(zmm_t9);
+    zmm[9] = bitonic_merge_zmm_64bit<vtype>(zmm_t10);
+    zmm[10] = bitonic_merge_zmm_64bit<vtype>(zmm_t11);
+    zmm[11] = bitonic_merge_zmm_64bit<vtype>(zmm_t12);
+    zmm[12] = bitonic_merge_zmm_64bit<vtype>(zmm_t13);
+    zmm[13] = bitonic_merge_zmm_64bit<vtype>(zmm_t14);
+    zmm[14] = bitonic_merge_zmm_64bit<vtype>(zmm_t15);
+    zmm[15] = bitonic_merge_zmm_64bit<vtype>(zmm_t16);
+    zmm[16] = bitonic_merge_zmm_64bit<vtype>(zmm_t17);
+    zmm[17] = bitonic_merge_zmm_64bit<vtype>(zmm_t18);
+    zmm[18] = bitonic_merge_zmm_64bit<vtype>(zmm_t19);
+    zmm[19] = bitonic_merge_zmm_64bit<vtype>(zmm_t20);
+    zmm[20] = bitonic_merge_zmm_64bit<vtype>(zmm_t21);
+    zmm[21] = bitonic_merge_zmm_64bit<vtype>(zmm_t22);
+    zmm[22] = bitonic_merge_zmm_64bit<vtype>(zmm_t23);
+    zmm[23] = bitonic_merge_zmm_64bit<vtype>(zmm_t24);
+    zmm[24] = bitonic_merge_zmm_64bit<vtype>(zmm_t25);
+    zmm[25] = bitonic_merge_zmm_64bit<vtype>(zmm_t26);
+    zmm[26] = bitonic_merge_zmm_64bit<vtype>(zmm_t27);
+    zmm[27] = bitonic_merge_zmm_64bit<vtype>(zmm_t28);
+    zmm[28] = bitonic_merge_zmm_64bit<vtype>(zmm_t29);
+    zmm[29] = bitonic_merge_zmm_64bit<vtype>(zmm_t30);
+    zmm[30] = bitonic_merge_zmm_64bit<vtype>(zmm_t31);
+    zmm[31] = bitonic_merge_zmm_64bit<vtype>(zmm_t32);
+}
+
 template <typename vtype, typename type_t>
 X86_SIMD_SORT_INLINE void sort_8_64bit(type_t *arr, int32_t N)
 {
@@ -372,6 +527,197 @@ X86_SIMD_SORT_INLINE void sort_128_64bit(type_t *arr, int32_t N)
 }
 
 template <typename vtype, typename type_t>
+X86_SIMD_SORT_INLINE void sort_256_64bit(type_t *arr, int32_t N)
+{
+    if (N <= 128) {
+        sort_128_64bit<vtype>(arr, N);
+        return;
+    }
+    using zmm_t = typename vtype::zmm_t;
+    using opmask_t = typename vtype::opmask_t;
+    zmm_t zmm[32];
+    zmm[0] = vtype::loadu(arr);
+    zmm[1] = vtype::loadu(arr + 8);
+    zmm[2] = vtype::loadu(arr + 16);
+    zmm[3] = vtype::loadu(arr + 24);
+    zmm[4] = vtype::loadu(arr + 32);
+    zmm[5] = vtype::loadu(arr + 40);
+    zmm[6] = vtype::loadu(arr + 48);
+    zmm[7] = vtype::loadu(arr + 56);
+    zmm[8] = vtype::loadu(arr + 64);
+    zmm[9] = vtype::loadu(arr + 72);
+    zmm[10] = vtype::loadu(arr + 80);
+    zmm[11] = vtype::loadu(arr + 88);
+    zmm[12] = vtype::loadu(arr + 96);
+    zmm[13] = vtype::loadu(arr + 104);
+    zmm[14] = vtype::loadu(arr + 112);
+    zmm[15] = vtype::loadu(arr + 120);
+    zmm[0] = sort_zmm_64bit<vtype>(zmm[0]);
+    zmm[1] = sort_zmm_64bit<vtype>(zmm[1]);
+    zmm[2] = sort_zmm_64bit<vtype>(zmm[2]);
+    zmm[3] = sort_zmm_64bit<vtype>(zmm[3]);
+    zmm[4] = sort_zmm_64bit<vtype>(zmm[4]);
+    zmm[5] = sort_zmm_64bit<vtype>(zmm[5]);
+    zmm[6] = sort_zmm_64bit<vtype>(zmm[6]);
+    zmm[7] = sort_zmm_64bit<vtype>(zmm[7]);
+    zmm[8] = sort_zmm_64bit<vtype>(zmm[8]);
+    zmm[9] = sort_zmm_64bit<vtype>(zmm[9]);
+    zmm[10] = sort_zmm_64bit<vtype>(zmm[10]);
+    zmm[11] = sort_zmm_64bit<vtype>(zmm[11]);
+    zmm[12] = sort_zmm_64bit<vtype>(zmm[12]);
+    zmm[13] = sort_zmm_64bit<vtype>(zmm[13]);
+    zmm[14] = sort_zmm_64bit<vtype>(zmm[14]);
+    zmm[15] = sort_zmm_64bit<vtype>(zmm[15]);
+    opmask_t load_mask1 = 0xFF, load_mask2 = 0xFF;
+    opmask_t load_mask3 = 0xFF, load_mask4 = 0xFF;
+    opmask_t load_mask5 = 0xFF, load_mask6 = 0xFF;
+    opmask_t load_mask7 = 0xFF, load_mask8 = 0xFF;
+    opmask_t load_mask9 = 0xFF, load_mask10 = 0xFF;
+    opmask_t load_mask11 = 0xFF, load_mask12 = 0xFF;
+    opmask_t load_mask13 = 0xFF, load_mask14 = 0xFF;
+    opmask_t load_mask15 = 0xFF, load_mask16 = 0xFF;
+    if (N != 256) {
+        uint64_t combined_mask;
+        if (N < 192) {
+            combined_mask = (0x1ull << (N - 128)) - 0x1ull;
+            load_mask1 = (combined_mask) & 0xFF;
+            load_mask2 = (combined_mask >> 8) & 0xFF;
+            load_mask3 = (combined_mask >> 16) & 0xFF;
+            load_mask4 = (combined_mask >> 24) & 0xFF;
+            load_mask5 = (combined_mask >> 32) & 0xFF;
+            load_mask6 = (combined_mask >> 40) & 0xFF;
+            load_mask7 = (combined_mask >> 48) & 0xFF;
+            load_mask8 = (combined_mask >> 56) & 0xFF;
+            load_mask9 = 0x00; load_mask10 = 0x0;
+            load_mask11 = 0x00; load_mask12 = 0x00;
+            load_mask13 = 0x00; load_mask14 = 0x00;
+            load_mask15 = 0x00; load_mask16 = 0x00;
+        }
+        else {
+            combined_mask = (0x1ull << (N - 192)) - 0x1ull;
+            load_mask9  = (combined_mask) & 0xFF;
+            load_mask10 = (combined_mask >> 8) & 0xFF;
+            load_mask11 = (combined_mask >> 16) & 0xFF;
+            load_mask12 = (combined_mask >> 24) & 0xFF;
+            load_mask13 = (combined_mask >> 32) & 0xFF;
+            load_mask14 = (combined_mask >> 40) & 0xFF;
+            load_mask15 = (combined_mask >> 48) & 0xFF;
+            load_mask16 = (combined_mask >> 56) & 0xFF;
+        }
+    }
+    zmm[16] = vtype::mask_loadu(vtype::zmm_max(), load_mask1, arr + 128);
+    zmm[17] = vtype::mask_loadu(vtype::zmm_max(), load_mask2, arr + 136);
+    zmm[18] = vtype::mask_loadu(vtype::zmm_max(), load_mask3, arr + 144);
+    zmm[19] = vtype::mask_loadu(vtype::zmm_max(), load_mask4, arr + 152);
+    zmm[20] = vtype::mask_loadu(vtype::zmm_max(), load_mask5, arr + 160);
+    zmm[21] = vtype::mask_loadu(vtype::zmm_max(), load_mask6, arr + 168);
+    zmm[22] = vtype::mask_loadu(vtype::zmm_max(), load_mask7, arr + 176);
+    zmm[23] = vtype::mask_loadu(vtype::zmm_max(), load_mask8, arr + 184);
+    if (N < 192) {
+        zmm[24] = vtype::zmm_max();
+        zmm[25] = vtype::zmm_max();
+        zmm[26] = vtype::zmm_max();
+        zmm[27] = vtype::zmm_max();
+        zmm[28] = vtype::zmm_max();
+        zmm[29] = vtype::zmm_max();
+        zmm[30] = vtype::zmm_max();
+        zmm[31] = vtype::zmm_max();
+    }
+    else {
+        zmm[24] = vtype::mask_loadu(vtype::zmm_max(), load_mask9, arr + 192);
+        zmm[25] = vtype::mask_loadu(vtype::zmm_max(), load_mask10, arr + 200);
+        zmm[26] = vtype::mask_loadu(vtype::zmm_max(), load_mask11, arr + 208);
+        zmm[27] = vtype::mask_loadu(vtype::zmm_max(), load_mask12, arr + 216);
+        zmm[28] = vtype::mask_loadu(vtype::zmm_max(), load_mask13, arr + 224);
+        zmm[29] = vtype::mask_loadu(vtype::zmm_max(), load_mask14, arr + 232);
+        zmm[30] = vtype::mask_loadu(vtype::zmm_max(), load_mask15, arr + 240);
+        zmm[31] = vtype::mask_loadu(vtype::zmm_max(), load_mask16, arr + 248);
+    }
+    zmm[16] = sort_zmm_64bit<vtype>(zmm[16]);
+    zmm[17] = sort_zmm_64bit<vtype>(zmm[17]);
+    zmm[18] = sort_zmm_64bit<vtype>(zmm[18]);
+    zmm[19] = sort_zmm_64bit<vtype>(zmm[19]);
+    zmm[20] = sort_zmm_64bit<vtype>(zmm[20]);
+    zmm[21] = sort_zmm_64bit<vtype>(zmm[21]);
+    zmm[22] = sort_zmm_64bit<vtype>(zmm[22]);
+    zmm[23] = sort_zmm_64bit<vtype>(zmm[23]);
+    zmm[24] = sort_zmm_64bit<vtype>(zmm[24]);
+    zmm[25] = sort_zmm_64bit<vtype>(zmm[25]);
+    zmm[26] = sort_zmm_64bit<vtype>(zmm[26]);
+    zmm[27] = sort_zmm_64bit<vtype>(zmm[27]);
+    zmm[28] = sort_zmm_64bit<vtype>(zmm[28]);
+    zmm[29] = sort_zmm_64bit<vtype>(zmm[29]);
+    zmm[30] = sort_zmm_64bit<vtype>(zmm[30]);
+    zmm[31] = sort_zmm_64bit<vtype>(zmm[31]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[0], zmm[1]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[2], zmm[3]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[4], zmm[5]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[6], zmm[7]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[8], zmm[9]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[10], zmm[11]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[12], zmm[13]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[14], zmm[15]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[16], zmm[17]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[18], zmm[19]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[20], zmm[21]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[22], zmm[23]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[24], zmm[25]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[26], zmm[27]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[28], zmm[29]);
+    bitonic_merge_two_zmm_64bit<vtype>(zmm[30], zmm[31]);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 4);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 8);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 12);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 16);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 20);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 24);
+    bitonic_merge_four_zmm_64bit<vtype>(zmm + 28);
+    bitonic_merge_eight_zmm_64bit<vtype>(zmm);
+    bitonic_merge_eight_zmm_64bit<vtype>(zmm + 8);
+    bitonic_merge_eight_zmm_64bit<vtype>(zmm + 16);
+    bitonic_merge_eight_zmm_64bit<vtype>(zmm + 24);
+    bitonic_merge_sixteen_zmm_64bit<vtype>(zmm);
+    bitonic_merge_sixteen_zmm_64bit<vtype>(zmm + 16);
+    bitonic_merge_32_zmm_64bit<vtype>(zmm);
+    vtype::storeu(arr, zmm[0]);
+    vtype::storeu(arr + 8, zmm[1]);
+    vtype::storeu(arr + 16, zmm[2]);
+    vtype::storeu(arr + 24, zmm[3]);
+    vtype::storeu(arr + 32, zmm[4]);
+    vtype::storeu(arr + 40, zmm[5]);
+    vtype::storeu(arr + 48, zmm[6]);
+    vtype::storeu(arr + 56, zmm[7]);
+    vtype::storeu(arr + 64, zmm[8]);
+    vtype::storeu(arr + 72, zmm[9]);
+    vtype::storeu(arr + 80, zmm[10]);
+    vtype::storeu(arr + 88, zmm[11]);
+    vtype::storeu(arr + 96, zmm[12]);
+    vtype::storeu(arr + 104, zmm[13]);
+    vtype::storeu(arr + 112, zmm[14]);
+    vtype::storeu(arr + 120, zmm[15]);
+    vtype::mask_storeu(arr + 128, load_mask1, zmm[16]);
+    vtype::mask_storeu(arr + 136, load_mask2, zmm[17]);
+    vtype::mask_storeu(arr + 144, load_mask3, zmm[18]);
+    vtype::mask_storeu(arr + 152, load_mask4, zmm[19]);
+    vtype::mask_storeu(arr + 160, load_mask5, zmm[20]);
+    vtype::mask_storeu(arr + 168, load_mask6, zmm[21]);
+    vtype::mask_storeu(arr + 176, load_mask7, zmm[22]);
+    vtype::mask_storeu(arr + 184, load_mask8, zmm[23]);
+    if (N > 192) {
+        vtype::mask_storeu(arr + 192, load_mask9, zmm[24]);
+        vtype::mask_storeu(arr + 200, load_mask10, zmm[25]);
+        vtype::mask_storeu(arr + 208, load_mask11, zmm[26]);
+        vtype::mask_storeu(arr + 216, load_mask12, zmm[27]);
+        vtype::mask_storeu(arr + 224, load_mask13, zmm[28]);
+        vtype::mask_storeu(arr + 232, load_mask14, zmm[29]);
+        vtype::mask_storeu(arr + 240, load_mask15, zmm[30]);
+        vtype::mask_storeu(arr + 248, load_mask16, zmm[31]);
+    }
+
+}
+
+template <typename vtype, typename type_t>
 static void
 qsort_64bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
 {
@@ -385,8 +731,8 @@ qsort_64bit_(type_t *arr, int64_t left, int64_t right, int64_t max_iters)
     /*
      * Base case: use bitonic networks to sort arrays <= 128
      */
-    if (right + 1 - left <= 128) {
-        sort_128_64bit<vtype>(arr + left, (int32_t)(right + 1 - left));
+    if (right + 1 - left <= 256) {
+        sort_256_64bit<vtype>(arr + left, (int32_t)(right + 1 - left));
         return;
     }
 

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -95,7 +95,8 @@ void avx512_qselect(T *arr, int64_t k, int64_t arrsize);
 void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize);
 
 template <typename T>
-inline void avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize) {
+inline void avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize)
+{
     avx512_qselect<T>(arr, k - 1, arrsize);
     avx512_qsort<T>(arr, k - 1);
 }

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -260,7 +260,9 @@ static inline int64_t partition_avx512(type_t *arr,
     return l_store;
 }
 
-template <typename vtype, typename type_t>
+template <typename vtype,
+          int num_unroll,
+          typename type_t = typename vtype::type_t>
 static inline int64_t partition_avx512_unrolled(type_t *arr,
                                                 int64_t left,
                                                 int64_t right,
@@ -268,7 +270,6 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
                                                 type_t *smallest,
                                                 type_t *biggest)
 {
-    const int num_unroll = 8;
     if (right - left <= 2 * num_unroll * vtype::numlanes) {
         return partition_avx512<vtype>(
                 arr, left, right, pivot, smallest, biggest);

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -269,11 +269,13 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
                                                 type_t *biggest)
 {
     const int num_unroll = 8;
-    if (right - left <= 2*num_unroll*vtype::numlanes) {
-        return partition_avx512<vtype>(arr, left, right, pivot, smallest, biggest);
+    if (right - left <= 2 * num_unroll * vtype::numlanes) {
+        return partition_avx512<vtype>(
+                arr, left, right, pivot, smallest, biggest);
     }
     /* make array length divisible by 8*vtype::numlanes , shortening the array */
-    for (int32_t i = ((right - left) % (num_unroll*vtype::numlanes)); i > 0; --i) {
+    for (int32_t i = ((right - left) % (num_unroll * vtype::numlanes)); i > 0;
+         --i) {
         *smallest = std::min(*smallest, arr[left], comparison_func<vtype>);
         *biggest = std::max(*biggest, arr[left], comparison_func<vtype>);
         if (!comparison_func<vtype>(arr[left], pivot)) {
@@ -295,17 +297,18 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
     // We will now have atleast 16 registers worth of data to process:
     // left and right vtype::numlanes values are partitioned at the end
     zmm_t vec_left[num_unroll], vec_right[num_unroll];
-    #pragma GCC unroll 8
+#pragma GCC unroll 8
     for (int ii = 0; ii < num_unroll; ++ii) {
-        vec_left[ii] = vtype::loadu(arr + left + vtype::numlanes*ii);
-        vec_right[ii] = vtype::loadu(arr + (right - vtype::numlanes*(num_unroll-ii)));
+        vec_left[ii] = vtype::loadu(arr + left + vtype::numlanes * ii);
+        vec_right[ii] = vtype::loadu(
+                arr + (right - vtype::numlanes * (num_unroll - ii)));
     }
     // store points of the vectors
     int64_t r_store = right - vtype::numlanes;
     int64_t l_store = left;
     // indices for loading the elements
-    left += num_unroll*vtype::numlanes;
-    right -= num_unroll*vtype::numlanes;
+    left += num_unroll * vtype::numlanes;
+    right -= num_unroll * vtype::numlanes;
     while (right - left != 0) {
         zmm_t curr_vec[num_unroll];
         /*
@@ -314,21 +317,21 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
          * otherwise from the left side
          */
         if ((r_store + vtype::numlanes) - right < left - l_store) {
-            right -= num_unroll*vtype::numlanes;
-            #pragma GCC unroll 8
+            right -= num_unroll * vtype::numlanes;
+#pragma GCC unroll 8
             for (int ii = 0; ii < num_unroll; ++ii) {
-                curr_vec[ii] = vtype::loadu(arr + right + ii*vtype::numlanes);
+                curr_vec[ii] = vtype::loadu(arr + right + ii * vtype::numlanes);
             }
         }
         else {
-            #pragma GCC unroll 8
+#pragma GCC unroll 8
             for (int ii = 0; ii < num_unroll; ++ii) {
-                curr_vec[ii] = vtype::loadu(arr + left + ii*vtype::numlanes);
+                curr_vec[ii] = vtype::loadu(arr + left + ii * vtype::numlanes);
             }
-            left += num_unroll*vtype::numlanes;
+            left += num_unroll * vtype::numlanes;
         }
-        // partition the current vector and save it on both sides of the array
-        #pragma GCC unroll 8
+// partition the current vector and save it on both sides of the array
+#pragma GCC unroll 8
         for (int ii = 0; ii < num_unroll; ++ii) {
             int32_t amount_ge_pivot
                     = partition_vec<vtype>(arr,
@@ -336,35 +339,37 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
                                            r_store + vtype::numlanes,
                                            curr_vec[ii],
                                            pivot_vec,
-                                           &min_vec,pick
+                                           &min_vec,
                                            &max_vec);
             l_store += (vtype::numlanes - amount_ge_pivot);
             r_store -= amount_ge_pivot;
         }
     }
 
-    /* partition and save vec_left[8] and vec_right[8] */
-    #pragma GCC unroll 8
+/* partition and save vec_left[8] and vec_right[8] */
+#pragma GCC unroll 8
     for (int ii = 0; ii < num_unroll; ++ii) {
-        int32_t amount_ge_pivot = partition_vec<vtype>(arr,
-                                                       l_store,
-                                                       r_store + vtype::numlanes,
-                                                       vec_left[ii],
-                                                       pivot_vec,
-                                                       &min_vec,
-                                                       &max_vec);
+        int32_t amount_ge_pivot
+                = partition_vec<vtype>(arr,
+                                       l_store,
+                                       r_store + vtype::numlanes,
+                                       vec_left[ii],
+                                       pivot_vec,
+                                       &min_vec,
+                                       &max_vec);
         l_store += (vtype::numlanes - amount_ge_pivot);
         r_store -= amount_ge_pivot;
     }
-    #pragma GCC unroll 8
+#pragma GCC unroll 8
     for (int ii = 0; ii < num_unroll; ++ii) {
-        int32_t amount_ge_pivot = partition_vec<vtype>(arr,
-                                                       l_store,
-                                                       r_store + vtype::numlanes,
-                                                       vec_right[ii],
-                                                       pivot_vec,
-                                                       &min_vec,
-                                                       &max_vec);
+        int32_t amount_ge_pivot
+                = partition_vec<vtype>(arr,
+                                       l_store,
+                                       r_store + vtype::numlanes,
+                                       vec_right[ii],
+                                       pivot_vec,
+                                       &min_vec,
+                                       &max_vec);
         l_store += (vtype::numlanes - amount_ge_pivot);
         r_store -= amount_ge_pivot;
     }

--- a/tests/test_keyvalue.cpp
+++ b/tests/test_keyvalue.cpp
@@ -4,8 +4,8 @@
  * *******************************************/
 
 #include "avx512-64bit-keyvaluesort.hpp"
-#include "rand_array.h"
 #include "cpuinfo.h"
+#include "rand_array.h"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/test_partial_qsort.hpp
+++ b/tests/test_partial_qsort.hpp
@@ -30,7 +30,8 @@ TYPED_TEST_P(avx512_partial_sort, test_ranges)
             int k = get_uniform_rand_array<int64_t>(1, arrsize, 1).front();
 
             /* Sort the range and verify all the required elements match the presorted set */
-            avx512_partial_qsort<TypeParam>(psortedarr.data(), k, psortedarr.size());
+            avx512_partial_qsort<TypeParam>(
+                    psortedarr.data(), k, psortedarr.size());
             for (size_t jj = 0; jj < k; jj++) {
                 ASSERT_EQ(sortedarr[jj], psortedarr[jj]);
             }

--- a/tests/test_qselect.hpp
+++ b/tests/test_qselect.hpp
@@ -5,7 +5,7 @@ class avx512_select : public ::testing::Test {
 };
 TYPED_TEST_SUITE_P(avx512_select);
 
-TYPED_TEST_P(avx512_select, test_arrsizes)
+TYPED_TEST_P(avx512_select, test_random)
 {
     if (cpu_has_avx512bw()) {
         if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
@@ -48,4 +48,47 @@ TYPED_TEST_P(avx512_select, test_arrsizes)
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(avx512_select, test_arrsizes);
+TYPED_TEST_P(avx512_select, test_small_range)
+{
+    if (cpu_has_avx512bw()) {
+        if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
+            GTEST_SKIP() << "Skipping this test, it requires avx512_vbmi2";
+        }
+        std::vector<int64_t> arrsizes;
+        for (int64_t ii = 0; ii < 1024; ++ii) {
+            arrsizes.push_back(ii);
+        }
+        std::vector<TypeParam> arr;
+        std::vector<TypeParam> sortedarr;
+        std::vector<TypeParam> psortedarr;
+        for (size_t ii = 0; ii < arrsizes.size(); ++ii) {
+            /* Random array */
+            arr = get_uniform_rand_array<TypeParam>(arrsizes[ii], 20, 1);
+            sortedarr = arr;
+            /* Sort with std::sort for comparison */
+            std::sort(sortedarr.begin(), sortedarr.end());
+            for (size_t k = 0; k < arr.size(); ++k) {
+                psortedarr = arr;
+                avx512_qselect<TypeParam>(psortedarr.data(), k, psortedarr.size());
+                /* index k is correct */
+                ASSERT_EQ(sortedarr[k], psortedarr[k]);
+                /* Check left partition */
+                for (size_t jj = 0; jj < k; jj++) {
+                    ASSERT_LE(psortedarr[jj], psortedarr[k]);
+                }
+                /* Check right partition */
+                for (size_t jj = k+1; jj < arr.size(); jj++) {
+                    ASSERT_GE(psortedarr[jj], psortedarr[k]);
+                }
+                psortedarr.clear();
+            }
+            arr.clear();
+            sortedarr.clear();
+        }
+    }
+    else {
+        GTEST_SKIP() << "Skipping this test, it requires avx512bw";
+    }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(avx512_select, test_random, test_small_range);

--- a/tests/test_qselect.hpp
+++ b/tests/test_qselect.hpp
@@ -26,7 +26,8 @@ TYPED_TEST_P(avx512_select, test_random)
             std::sort(sortedarr.begin(), sortedarr.end());
             for (size_t k = 0; k < arr.size(); ++k) {
                 psortedarr = arr;
-                avx512_qselect<TypeParam>(psortedarr.data(), k, psortedarr.size());
+                avx512_qselect<TypeParam>(
+                        psortedarr.data(), k, psortedarr.size());
                 /* index k is correct */
                 ASSERT_EQ(sortedarr[k], psortedarr[k]);
                 /* Check left partition */
@@ -34,7 +35,7 @@ TYPED_TEST_P(avx512_select, test_random)
                     ASSERT_LE(psortedarr[jj], psortedarr[k]);
                 }
                 /* Check right partition */
-                for (size_t jj = k+1; jj < arr.size(); jj++) {
+                for (size_t jj = k + 1; jj < arr.size(); jj++) {
                     ASSERT_GE(psortedarr[jj], psortedarr[k]);
                 }
                 psortedarr.clear();
@@ -69,7 +70,8 @@ TYPED_TEST_P(avx512_select, test_small_range)
             std::sort(sortedarr.begin(), sortedarr.end());
             for (size_t k = 0; k < arr.size(); ++k) {
                 psortedarr = arr;
-                avx512_qselect<TypeParam>(psortedarr.data(), k, psortedarr.size());
+                avx512_qselect<TypeParam>(
+                        psortedarr.data(), k, psortedarr.size());
                 /* index k is correct */
                 ASSERT_EQ(sortedarr[k], psortedarr[k]);
                 /* Check left partition */
@@ -77,7 +79,7 @@ TYPED_TEST_P(avx512_select, test_small_range)
                     ASSERT_LE(psortedarr[jj], psortedarr[k]);
                 }
                 /* Check right partition */
-                for (size_t jj = k+1; jj < arr.size(); jj++) {
+                for (size_t jj = k + 1; jj < arr.size(); jj++) {
                     ASSERT_GE(psortedarr[jj], psortedarr[k]);
                 }
                 psortedarr.clear();

--- a/tests/test_qsort.hpp
+++ b/tests/test_qsort.hpp
@@ -10,7 +10,7 @@ class avx512_sort : public ::testing::Test {
 };
 TYPED_TEST_SUITE_P(avx512_sort);
 
-TYPED_TEST_P(avx512_sort, test_arrsizes)
+TYPED_TEST_P(avx512_sort, test_random)
 {
     if (cpu_has_avx512bw()) {
         if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
@@ -29,7 +29,7 @@ TYPED_TEST_P(avx512_sort, test_arrsizes)
             /* Sort with std::sort for comparison */
             std::sort(sortedarr.begin(), sortedarr.end());
             avx512_qsort<TypeParam>(arr.data(), arr.size());
-            ASSERT_EQ(sortedarr, arr);
+            ASSERT_EQ(sortedarr, arr) << "Array size = " << arrsizes[ii];
             arr.clear();
             sortedarr.clear();
         }
@@ -39,4 +39,94 @@ TYPED_TEST_P(avx512_sort, test_arrsizes)
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(avx512_sort, test_arrsizes);
+TYPED_TEST_P(avx512_sort, test_reverse)
+{
+    if (cpu_has_avx512bw()) {
+        if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
+            GTEST_SKIP() << "Skipping this test, it requires avx512_vbmi2";
+        }
+        std::vector<int64_t> arrsizes;
+        for (int64_t ii = 0; ii < 1024; ++ii) {
+            arrsizes.push_back((TypeParam) (ii + 1));
+        }
+        std::vector<TypeParam> arr;
+        std::vector<TypeParam> sortedarr;
+        for (size_t ii = 0; ii < arrsizes.size(); ++ii) {
+            /* reverse array */
+            for (int jj = 0; jj < arrsizes[ii]; ++jj) {
+                arr.push_back((TypeParam) (arrsizes[ii] - jj));
+            }
+            sortedarr = arr;
+            /* Sort with std::sort for comparison */
+            std::sort(sortedarr.begin(), sortedarr.end());
+            avx512_qsort<TypeParam>(arr.data(), arr.size());
+            ASSERT_EQ(sortedarr, arr) << "Array size = " << arrsizes[ii];
+            arr.clear();
+            sortedarr.clear();
+        }
+    }
+    else {
+        GTEST_SKIP() << "Skipping this test, it requires avx512bw";
+    }
+}
+
+TYPED_TEST_P(avx512_sort, test_constant)
+{
+    if (cpu_has_avx512bw()) {
+        if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
+            GTEST_SKIP() << "Skipping this test, it requires avx512_vbmi2";
+        }
+        std::vector<int64_t> arrsizes;
+        for (int64_t ii = 0; ii < 1024; ++ii) {
+            arrsizes.push_back((TypeParam) (ii + 1));
+        }
+        std::vector<TypeParam> arr;
+        std::vector<TypeParam> sortedarr;
+        for (size_t ii = 0; ii < arrsizes.size(); ++ii) {
+            /* constant array */
+            for (int jj = 0; jj < arrsizes[ii]; ++jj) {
+                arr.push_back(ii);
+            }
+            sortedarr = arr;
+            /* Sort with std::sort for comparison */
+            std::sort(sortedarr.begin(), sortedarr.end());
+            avx512_qsort<TypeParam>(arr.data(), arr.size());
+            ASSERT_EQ(sortedarr, arr) << "Array size = " << arrsizes[ii];
+            arr.clear();
+            sortedarr.clear();
+        }
+    }
+    else {
+        GTEST_SKIP() << "Skipping this test, it requires avx512bw";
+    }
+}
+
+TYPED_TEST_P(avx512_sort, test_small_range)
+{
+    if (cpu_has_avx512bw()) {
+        if ((sizeof(TypeParam) == 2) && (!cpu_has_avx512_vbmi2())) {
+            GTEST_SKIP() << "Skipping this test, it requires avx512_vbmi2";
+        }
+        std::vector<int64_t> arrsizes;
+        for (int64_t ii = 0; ii < 1024; ++ii) {
+            arrsizes.push_back((TypeParam) (ii + 1));
+        }
+        std::vector<TypeParam> arr;
+        std::vector<TypeParam> sortedarr;
+        for (size_t ii = 0; ii < arrsizes.size(); ++ii) {
+            arr = get_uniform_rand_array<TypeParam>(arrsizes[ii], 20, 1);
+            sortedarr = arr;
+            /* Sort with std::sort for comparison */
+            std::sort(sortedarr.begin(), sortedarr.end());
+            avx512_qsort<TypeParam>(arr.data(), arr.size());
+            ASSERT_EQ(sortedarr, arr) << "Array size = " << arrsizes[ii];
+            arr.clear();
+            sortedarr.clear();
+        }
+    }
+    else {
+        GTEST_SKIP() << "Skipping this test, it requires avx512bw";
+    }
+}
+REGISTER_TYPED_TEST_SUITE_P(avx512_sort,
+        test_random, test_reverse, test_constant, test_small_range);

--- a/tests/test_qsort.hpp
+++ b/tests/test_qsort.hpp
@@ -47,14 +47,14 @@ TYPED_TEST_P(avx512_sort, test_reverse)
         }
         std::vector<int64_t> arrsizes;
         for (int64_t ii = 0; ii < 1024; ++ii) {
-            arrsizes.push_back((TypeParam) (ii + 1));
+            arrsizes.push_back((TypeParam)(ii + 1));
         }
         std::vector<TypeParam> arr;
         std::vector<TypeParam> sortedarr;
         for (size_t ii = 0; ii < arrsizes.size(); ++ii) {
             /* reverse array */
             for (int jj = 0; jj < arrsizes[ii]; ++jj) {
-                arr.push_back((TypeParam) (arrsizes[ii] - jj));
+                arr.push_back((TypeParam)(arrsizes[ii] - jj));
             }
             sortedarr = arr;
             /* Sort with std::sort for comparison */
@@ -78,7 +78,7 @@ TYPED_TEST_P(avx512_sort, test_constant)
         }
         std::vector<int64_t> arrsizes;
         for (int64_t ii = 0; ii < 1024; ++ii) {
-            arrsizes.push_back((TypeParam) (ii + 1));
+            arrsizes.push_back((TypeParam)(ii + 1));
         }
         std::vector<TypeParam> arr;
         std::vector<TypeParam> sortedarr;
@@ -109,7 +109,7 @@ TYPED_TEST_P(avx512_sort, test_small_range)
         }
         std::vector<int64_t> arrsizes;
         for (int64_t ii = 0; ii < 1024; ++ii) {
-            arrsizes.push_back((TypeParam) (ii + 1));
+            arrsizes.push_back((TypeParam)(ii + 1));
         }
         std::vector<TypeParam> arr;
         std::vector<TypeParam> sortedarr;
@@ -129,4 +129,7 @@ TYPED_TEST_P(avx512_sort, test_small_range)
     }
 }
 REGISTER_TYPED_TEST_SUITE_P(avx512_sort,
-        test_random, test_reverse, test_constant, test_small_range);
+                            test_random,
+                            test_reverse,
+                            test_constant,
+                            test_small_range);

--- a/tests/test_qsortfp16.cpp
+++ b/tests/test_qsortfp16.cpp
@@ -95,7 +95,8 @@ TEST(avx512_qselect_float16, test_arrsizes)
             std::sort(sortedarr.begin(), sortedarr.end());
             for (size_t k = 0; k < arr.size(); ++k) {
                 psortedarr = arr;
-                avx512_qselect<_Float16>(psortedarr.data(), k, psortedarr.size());
+                avx512_qselect<_Float16>(
+                        psortedarr.data(), k, psortedarr.size());
                 /* index k is correct */
                 ASSERT_EQ(sortedarr[k], psortedarr[k]);
                 /* Check left partition */
@@ -103,7 +104,7 @@ TEST(avx512_qselect_float16, test_arrsizes)
                     ASSERT_LE(psortedarr[jj], psortedarr[k]);
                 }
                 /* Check right partition */
-                for (size_t jj = k+1; jj < arr.size(); jj++) {
+                for (size_t jj = k + 1; jj < arr.size(); jj++) {
                     ASSERT_GE(psortedarr[jj], psortedarr[k]);
                 }
                 psortedarr.clear();
@@ -142,7 +143,8 @@ TEST(avx512_partial_qsort_float16, test_ranges)
             int k = get_uniform_rand_array<int64_t>(1, arrsize, 1).front();
 
             /* Sort the range and verify all the required elements match the presorted set */
-            avx512_partial_qsort<_Float16>(psortedarr.data(), k, psortedarr.size());
+            avx512_partial_qsort<_Float16>(
+                    psortedarr.data(), k, psortedarr.size());
             for (size_t jj = 0; jj < k; jj++) {
                 ASSERT_EQ(sortedarr[jj], psortedarr[jj]);
             }

--- a/tests/test_sort.cpp
+++ b/tests/test_sort.cpp
@@ -1,6 +1,6 @@
-#include "test_qsort.hpp"
-#include "test_qselect.hpp"
 #include "test_partial_qsort.hpp"
+#include "test_qselect.hpp"
+#include "test_qsort.hpp"
 
 using QuickSortTestTypes = testing::Types<uint16_t,
                                           int16_t,
@@ -12,4 +12,6 @@ using QuickSortTestTypes = testing::Types<uint16_t,
                                           int64_t>;
 INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, avx512_sort, QuickSortTestTypes);
 INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, avx512_select, QuickSortTestTypes);
-INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, avx512_partial_sort, QuickSortTestTypes);
+INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix,
+                               avx512_partial_sort,
+                               QuickSortTestTypes);


### PR DESCRIPTION
- Add a larger network oto see if it helps at all.  
- Added an unrolled version of partition_avx512 (based on https://github.com/simd-sorting/fast-and-robust/blob/054f2e2e9f7c00be4dc8d69567f92ddf9832a8f3/avx2_sort_demo/avx2sort.h#L774). 

benchmark comparison: 

## 64-bit improvements: 

up-to 1.64x speed up for `avx512_qsort`, `avx512_qselect` and `avx512_partial_qsort `using the unrolled avx512_partition: 

```
Benchmark                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------
avx512_qsort<double>/10000                         -0.2855         -0.2855         80600         57586         80608         57595
avx512_qsort<double>/1000000                       -0.3934         -0.3934      16793069      10187304      16792501      10186808
avx512_qsort<uint64_t>/10000                       -0.2095         -0.2096         85913         67912         85927         67917
avx512_qsort<uint64_t>/1000000                     -0.3451         -0.3451      17036085      11156221      17035521      11155822
avx512_qsort<int64_t>/10000                        -0.1953         -0.1952         84153         67721         84159         67728
avx512_qsort<int64_t>/1000000                      -0.3479         -0.3479      17082368      11138920      17081635      11138410
avx512_partial_qsort<double>/10                    -0.1180         -0.1176          9909          8740          9910          8745
avx512_partial_qsort<double>/100                   -0.0999         -0.0996          9938          8946          9942          8951
avx512_partial_qsort<double>/1000                  -0.0519         -0.0517         13879         13159         13885         13167
avx512_partial_qsort<double>/5000                  -0.2305         -0.2304         46276         35610         46283         35618
avx512_partial_qsort<uint64_t>/10                  -0.3791         -0.3790         11295          7013         11300          7018
avx512_partial_qsort<uint64_t>/100                 -0.3612         -0.3613         11530          7365         11538          7370
avx512_partial_qsort<uint64_t>/1000                -0.3142         -0.3141         17270         11844         17277         11851
avx512_partial_qsort<uint64_t>/5000                -0.0923         -0.0923         44120         40048         44128         40054
avx512_partial_qsort<int64_t>/10                   -0.3567         -0.3565         10923          7027         10927          7031
avx512_partial_qsort<int64_t>/100                  -0.3503         -0.3503         11342          7369         11348          7373
avx512_partial_qsort<int64_t>/1000                 -0.3053         -0.3051         17040         11838         17046         11844
avx512_partial_qsort<int64_t>/5000                 -0.0884         -0.0884         43852         39976         43860         39982
avx512_qselect<double>/10                          -0.1167         -0.1164          9885          8731          9888          8737
avx512_qselect<double>/100                         -0.1020         -0.1017          9721          8729          9724          8735
avx512_qselect<double>/1000                        -0.0445         -0.0443          9098          8693          9103          8699
avx512_qselect<double>/5000                        -0.2248         -0.2246         11236          8710         11241          8716
avx512_qselect<uint64_t>/10                        -0.3807         -0.3806         11246          6965         11253          6969
avx512_qselect<uint64_t>/100                       -0.3769         -0.3768         11213          6987         11219          6992
avx512_qselect<uint64_t>/1000                      -0.3964         -0.3964         11364          6859         11369          6863
avx512_qselect<uint64_t>/5000                      -0.2009         -0.2010          9211          7360          9218          7365
avx512_qselect<int64_t>/10                         -0.3645         -0.3643         10959          6964         10963          6969
avx512_qselect<int64_t>/100                        -0.3626         -0.3624         10951          6980         10956          6986
avx512_qselect<int64_t>/1000                       -0.3825         -0.3823         11069          6836         11074          6841
avx512_qselect<int64_t>/5000                       -0.1803         -0.1800          8976          7358          8981          7364

```

## 32-bit improvements:

up-to 1.2 - 1.3x speed up for `avx512_qsort`, `avx512_qselect` and `avx512_partial_qsort `using the unrolled avx512_partition: 

```
avx512_qsort<float>/10000                          -0.1018         -0.1016         46769         42010         46770         42018
avx512_qsort<float>/1000000                        -0.1857         -0.1857       8962300       7298007       8961476       7297402
avx512_qsort<uint32_t>/10000                       -0.0619         -0.0619         34952         32788         34955         32793
avx512_qsort<uint32_t>/1000000                     -0.1859         -0.1859       7746334       6306397       7745718       6305695
avx512_qsort<int32_t>/10000                        -0.0682         -0.0683         35036         32647         35043         32651
avx512_qsort<int32_t>/1000000                      -0.1849         -0.1849       7727002       6298105       7726168       6297432
avx512_qselect<float>/10                           -0.1104         -0.1098          6869          6111          6873          6118
avx512_qselect<float>/100                          -0.0951         -0.0945          6877          6223          6880          6230
avx512_qselect<float>/1000                         -0.1056         -0.1049          7035          6292          7039          6301
avx512_qselect<float>/5000                         -0.1129         -0.1123          6971          6185          6975          6192
avx512_qselect<uint32_t>/10                        -0.2647         -0.2638          6133          4510          6136          4517
avx512_qselect<uint32_t>/100                       -0.2555         -0.2548          6110          4549          6113          4556
avx512_qselect<uint32_t>/1000                      -0.1976         -0.1967          5996          4811          5999          4819
avx512_qselect<uint32_t>/5000                      -0.1522         -0.1516          6090          5164          6094          5170
avx512_qselect<int32_t>/10                         -0.2645         -0.2638          6173          4540          6176          4547
avx512_qselect<int32_t>/100                        -0.2581         -0.2574          6120          4540          6123          4547
avx512_qselect<int32_t>/1000                       -0.1941         -0.1934          5985          4823          5988          4830
avx512_qselect<int32_t>/5000                       -0.1629         -0.1625          6159          5156          6163          5162
avx512_partial_qsort<float>/10                     -0.1235         -0.1227          6977          6116          6980          6123
avx512_partial_qsort<float>/100                    -0.1017         -0.1014          7069          6350          7076          6358
avx512_partial_qsort<float>/1000                   -0.0707         -0.0703         10515          9772         10519          9779
avx512_partial_qsort<float>/5000                   -0.0633         -0.0632         26409         24737         26411         24743
avx512_partial_qsort<uint32_t>/10                  -0.2710         -0.2703          6229          4541          6231          4547
avx512_partial_qsort<uint32_t>/100                 -0.2583         -0.2576          6291          4666          6294          4673
avx512_partial_qsort<uint32_t>/1000                -0.1492         -0.1486          8610          7325          8613          7333
avx512_partial_qsort<uint32_t>/5000                -0.0702         -0.0701         22641         21052         22645         21058
avx512_partial_qsort<int32_t>/10                   -0.2590         -0.2583          6182          4581          6185          4588
avx512_partial_qsort<int32_t>/100                  -0.2527         -0.2520          6226          4653          6229          4659
avx512_partial_qsort<int32_t>/1000                 -0.1492         -0.1485          8629          7342          8632          7349
avx512_partial_qsort<int32_t>/5000                 -0.0734         -0.0732         22636         20974         22640         20982
```


