### PR TITLE
Replace intrinsic missing from g++-7

### DIFF
--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -285,7 +285,7 @@ struct ymm_vector<uint32_t> {
     }
     static void storeu(void *mem, zmm_t x)
     {
-        _mm256_storeu_epi32(mem, x);
+        _mm256_storeu_si256((__m256i*) mem, x);
     }
 };
 template <>
@@ -414,7 +414,7 @@ struct ymm_vector<int32_t> {
     }
     static void storeu(void *mem, zmm_t x)
     {
-        _mm256_storeu_epi32(mem, x);
+        _mm256_storeu_si256((__m256i*) mem, x);
     }
 };
 template <>


### PR DESCRIPTION
g++-7 is missing the _mm256_storeu_epi32 intrinsic. 