### PR TITLE
Update build configuration to reduce friction

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,7 +24,7 @@ jobs:
         git clone https://github.com/google/benchmark.git
         cd benchmark
         cmake -E make_directory "build"
-        cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../
+        cmake -E chdir "build" cmake -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ../
         sudo cmake --build "build" --config Release --target install
 
     - name: Install Intel SDE
@@ -86,7 +86,7 @@ jobs:
         cd benchmark
         pip3 install -r requirements.txt
         cmake -E make_directory "build"
-        cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../
+        cmake -E chdir "build" cmake -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ../
         sudo cmake --build "build" --config Release --target install
 
     - name: Run bench-compare

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@
 *.out
 *.app
 
+# Build or IDE artifacts
 **/.vscode
-
+/builddir/

--- a/benchmarks/main.cpp
+++ b/benchmarks/main.cpp
@@ -1,3 +1,0 @@
-#include <benchmark/benchmark.h>
-
-BENCHMARK_MAIN();

--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,8 @@ src = include_directories('src')
 bench = include_directories('benchmarks')
 utils = include_directories('utils')
 tests = include_directories('tests')
-gtest_dep = dependency('gtest_main', required : true)
-gbench_dep = dependency('benchmark', required : true)
+gtest_dep = dependency('gtest_main', required : true, static: true)
+gbench_dep = dependency('benchmark', required : true, static: true)
 
 fp16code = '''#include<immintrin.h>
 int main() { 
@@ -28,9 +28,10 @@ testexe = executable('testexe',
                      link_whole : [libtests, libcpuinfo]
                     )
 
-benchexe = executable('benchexe', 'benchmarks/main.cpp',
+benchexe = executable('benchexe',
                       include_directories : [src, utils, bench],
                       dependencies : [gbench_dep],
+                      link_args: ['-lbenchmark_main'],
                       link_whole : [libbench, libcpuinfo],
                      )
 


### PR DESCRIPTION
Basically I got annoyed that my Ubuntu 20.04 machine couldn't compile the benchmarks so I looked into it. I also updated the Makefile to have some available compiler smarts like Meson. Closes #44.

---

On systems with glibc < 2.34, the `-lpthread` option needs to be included when linking with Google's benchmark and test frameworks. However, the `pkg-config` command for `benchmark` needs to be explicitly given the `--static` flag for this to be included. The static inclusion has also been added to the Meson configuration.

I've also included some rudimentary logic to allow the Makefile to shrink the scope of its compilation targets when an older compiler is being used. I changed the benchmarks to run using `benchmark_main` in the same way that the tests use `gtest_main`. Finally, I turned off compilation of the package-internal tests for Google Benchmarks when running in GitHub actions.