### PR TITLE
Add an optional argument "hasnan" for qselect and partialsort

### DIFF
--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -406,7 +406,13 @@ replace_inf_with_nan(uint16_t *arr, int64_t arrsize, int64_t nan_count)
 }
 
 template <>
-void avx512_qselect(int16_t *arr, int64_t k, int64_t arrsize)
+bool is_a_nan<uint16_t>(uint16_t elem)
+{
+    return (elem & 0x7c00) == 0x7c00;
+}
+
+template <>
+void avx512_qselect(int16_t *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
     if (arrsize > 1) {
         qselect_16bit_<zmm_vector<int16_t>, int16_t>(
@@ -415,7 +421,7 @@ void avx512_qselect(int16_t *arr, int64_t k, int64_t arrsize)
 }
 
 template <>
-void avx512_qselect(uint16_t *arr, int64_t k, int64_t arrsize)
+void avx512_qselect(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
     if (arrsize > 1) {
         qselect_16bit_<zmm_vector<uint16_t>, uint16_t>(
@@ -423,13 +429,15 @@ void avx512_qselect(uint16_t *arr, int64_t k, int64_t arrsize)
     }
 }
 
-void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize)
+void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
-    if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf(arr, arrsize);
+    int64_t indx_last_elem = arrsize - 1;
+    if (UNLIKELY(hasnan)) {
+         indx_last_elem = move_nans_to_end_of_array(arr, arrsize);
+    }
+    if (indx_last_elem >= k) {
         qselect_16bit_<zmm_vector<float16>, uint16_t>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-        replace_inf_with_nan(arr, arrsize, nan_count);
+            arr, k, 0, indx_last_elem, 2 * (int64_t)log2(indx_last_elem));
     }
 }
 

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -784,7 +784,7 @@ static void qselect_64bit_(type_t *arr,
 }
 
 template <>
-void avx512_qselect<int64_t>(int64_t *arr, int64_t k, int64_t arrsize)
+void avx512_qselect<int64_t>(int64_t *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
     if (arrsize > 1) {
         qselect_64bit_<zmm_vector<int64_t>, int64_t>(
@@ -793,7 +793,7 @@ void avx512_qselect<int64_t>(int64_t *arr, int64_t k, int64_t arrsize)
 }
 
 template <>
-void avx512_qselect<uint64_t>(uint64_t *arr, int64_t k, int64_t arrsize)
+void avx512_qselect<uint64_t>(uint64_t *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
     if (arrsize > 1) {
         qselect_64bit_<zmm_vector<uint64_t>, uint64_t>(
@@ -802,13 +802,15 @@ void avx512_qselect<uint64_t>(uint64_t *arr, int64_t k, int64_t arrsize)
 }
 
 template <>
-void avx512_qselect<double>(double *arr, int64_t k, int64_t arrsize)
+void avx512_qselect<double>(double *arr, int64_t k, int64_t arrsize, bool hasnan)
 {
-    if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf(arr, arrsize);
+    int64_t indx_last_elem = arrsize - 1;
+    if (UNLIKELY(hasnan)) {
+         indx_last_elem = move_nans_to_end_of_array(arr, arrsize);
+    }
+    if (indx_last_elem >= k) {
         qselect_64bit_<zmm_vector<double>, double>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-        replace_inf_with_nan(arr, arrsize, nan_count);
+            arr, k, 0, indx_last_elem, 2 * (int64_t)log2(indx_last_elem));
     }
 }
 

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -85,6 +85,9 @@
 #define X86_SIMD_SORT_FINLINE static
 #endif
 
+#define LIKELY(x)       __builtin_expect((x),1)
+#define UNLIKELY(x)     __builtin_expect((x),0)
+
 template <typename type>
 struct zmm_vector;
 
@@ -97,24 +100,53 @@ void avx512_qsort(T *arr, int64_t arrsize);
 void avx512_qsort_fp16(uint16_t *arr, int64_t arrsize);
 
 template <typename T>
-void avx512_qselect(T *arr, int64_t k, int64_t arrsize);
-void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize);
+void avx512_qselect(T *arr, int64_t k, int64_t arrsize, bool hasnan = false);
+void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan = false);
 
 template <typename T>
-inline void avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize)
+inline void avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize, bool hasnan = false)
 {
-    avx512_qselect<T>(arr, k - 1, arrsize);
+    avx512_qselect<T>(arr, k - 1, arrsize, hasnan);
     avx512_qsort<T>(arr, k - 1);
 }
-inline void avx512_partial_qsort_fp16(uint16_t *arr, int64_t k, int64_t arrsize)
+inline void avx512_partial_qsort_fp16(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan = false)
 {
-    avx512_qselect_fp16(arr, k - 1, arrsize);
+    avx512_qselect_fp16(arr, k - 1, arrsize, hasnan);
     avx512_qsort_fp16(arr, k - 1);
 }
 
 // key-value sort routines
 template <typename T>
 void avx512_qsort_kv(T *keys, uint64_t *indexes, int64_t arrsize);
+
+template <typename T>
+bool is_a_nan(T elem)
+{
+    return std::isnan(elem);
+}
+
+/*
+ * Sort all the NAN's to end of the array and return the index of the last elem
+ * in the array which is not a nan
+ */
+template <typename T>
+int64_t move_nans_to_end_of_array(T* arr, int64_t arrsize)
+{
+    int64_t jj = arrsize - 1;
+    int64_t ii = 0;
+    int64_t count = 0;
+    while (ii <= jj) {
+        if (is_a_nan(arr[ii])) {
+            std::swap(arr[ii], arr[jj]);
+            jj -= 1;
+            count++;
+        }
+        else {
+            ii += 1;
+        }
+    }
+    return arrsize-count-1;
+}
 
 template <typename vtype, typename T = typename vtype::type_t>
 bool comparison_func(const T &a, const T &b)


### PR DESCRIPTION
Handling NAN's slows down the algorithm. We make it an optional argument. Also fixes a bug in qselect and partialsort where NAN's were handled incorrectly. Improved benchmarks for float and doubles not containing NAN's:

```
Benchmark                                                                  Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------------------------
[avx512_qselect<double> vs. avx512_qselect<double>]/10                  -0.1488         -0.1488          8922          7594          8928          7600
[avx512_qselect<double> vs. avx512_qselect<double>]/100                 -0.1542         -0.1540          8963          7582          8970          7588
[avx512_qselect<double> vs. avx512_qselect<double>]/1000                -0.1615         -0.1617          8664          7265          8672          7269
[avx512_qselect<double> vs. avx512_qselect<double>]/5000                -0.1472         -0.1472          9705          8276          9711          8281
[avx512_qselect<float> vs. avx512_qselect<float>]/10                  -0.1708         -0.1706          6049          5016          6052          5019
[avx512_qselect<float> vs. avx512_qselect<float>]/100                 -0.1691         -0.1690          6171          5128          6174          5131
[avx512_qselect<float> vs. avx512_qselect<float>]/1000                -0.1645         -0.1643          6229          5204          6231          5207
[avx512_qselect<float> vs. avx512_qselect<float>]/5000                -0.1586         -0.1581          6140          5166          6143          5172

```

**Compared to stdnthelement:** 

```
Benchmark                                                                      Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------------
[stdpartialsort<float> vs. avx512_partial_qsort<float>]/10                  -0.2713         -0.2706          6952          5066          6953          5071
[stdpartialsort<float> vs. avx512_partial_qsort<float>]/100                 -0.7868         -0.7865         25051          5341         25053          5350
[stdpartialsort<float> vs. avx512_partial_qsort<float>]/1000                -0.9652         -0.9652        253841          8834        253840          8842
[stdpartialsort<float> vs. avx512_partial_qsort<float>]/5000                -0.9686         -0.9686        755803         23749        755779         23756
OVERALL_GEOMEAN                                                             -0.8858         -0.8857             0             0             0             0
```

```
Benchmark                                                                        Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------------------------------
[stdpartialsort<double> vs. avx512_partial_qsort<double>]/10                  -0.0438         -0.0429          7958          7609          7957          7616
[stdpartialsort<double> vs. avx512_partial_qsort<double>]/100                 -0.6967         -0.6963         25841          7839         25843          7848
[stdpartialsort<double> vs. avx512_partial_qsort<double>]/1000                -0.9505         -0.9505        243181         12033        243190         12043
[stdpartialsort<double> vs. avx512_partial_qsort<double>]/5000                -0.9480         -0.9480        694575         36117        694556         36134

```

ping @mosullivan93 