### PR TITLE
Further Makefile updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 # Build or IDE artifacts
 **/.vscode
 /builddir/
+/testexe
+/benchexe

--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,75 @@
 CXX		?= g++-12
-CXXFLAGS	+= -I$(SRCDIR) -I$(UTILS) -O3
-GTESTCFLAGS	= `pkg-config --cflags gtest_main`
-GTESTLDFLAGS	= `pkg-config --static --libs gtest_main`
-GBENCHCFLAGS	= `pkg-config --cflags benchmark`
-GBENCHLDFLAGS	= `pkg-config --static --libs benchmark`
-MARCHFLAG	= -march=sapphirerapids
+CXXFLAGS	+= $(OPTIMFLAG) $(MARCHFLAG)
+override CXXFLAGS += -I$(SRCDIR) -I$(UTILSDIR)
+GTESTCFLAGS	:= `pkg-config --cflags gtest_main`
+GTESTLDFLAGS	:= `pkg-config --static --libs gtest_main`
+GBENCHCFLAGS	:= `pkg-config --cflags benchmark`
+GBENCHLDFLAGS	:= `pkg-config --static --libs benchmark`
+OPTIMFLAG	:= -O3
+MARCHFLAG	:= -march=sapphirerapids
 
-SRCDIR		= ./src
-TESTDIR		= ./tests
-BENCHDIR	= ./benchmarks
-UTILS		= ./utils
-SRCS		= $(wildcard $(SRCDIR)/*.hpp)
-TESTS		= $(wildcard $(TESTDIR)/*.cpp)
-BENCHS		= $(wildcard $(BENCHDIR)/*.cpp)
-TESTOBJS	= $(patsubst $(TESTDIR)/%.cpp,$(TESTDIR)/%.o,$(TESTS))
-BENCHOBJS	= $(patsubst $(BENCHDIR)/%.cpp,$(BENCHDIR)/%.o,$(BENCHS))
+SRCDIR		:= ./src
+TESTDIR		:= ./tests
+BENCHDIR	:= ./benchmarks
+UTILSDIR	:= ./utils
 
-test_cxx_flag = $(shell 2>/dev/null $(CXX) -o /dev/null $(1) -c -x c++ /dev/null; echo $$?)
+SRCS		:= $(wildcard $(addprefix $(SRCDIR)/, *.hpp *.h))
+UTILSRCS	:= $(wildcard $(addprefix $(UTILSDIR)/, *.hpp *.h))
+TESTSRCS	:= $(wildcard $(addprefix $(TESTDIR)/, *.hpp *.h))
+BENCHSRCS	:= $(wildcard $(addprefix $(BENCHDIR)/, *.hpp *.h))
+UTILS		:= $(wildcard $(UTILSDIR)/*.cpp)
+TESTS		:= $(wildcard $(TESTDIR)/*.cpp)
+BENCHS		:= $(wildcard $(BENCHDIR)/*.cpp)
+
+test_cxx_flag	= $(shell 2>/dev/null $(CXX) -o /dev/null $(1) -c -x c++ /dev/null; echo $$?)
 
 # Compiling AVX512-FP16 instructions wasn't possible until GCC 12
 ifeq ($(call test_cxx_flag,-mavx512fp16), 1)
-  BENCHOBJS_SKIP += bench-qsortfp16.o
-  TESTOBJS_SKIP += test-qsortfp16.o
+  BENCHS_SKIP	+= bench-qsortfp16.cpp
+  TESTS_SKIP 	+= test-qsortfp16.cpp
 endif
 
 # Sapphire Rapids was otherwise supported from GCC 11. Downgrade if required.
 ifeq ($(call test_cxx_flag,$(MARCHFLAG)), 1)
-  MARCHFLAG = -march=icelake-client
+  MARCHFLAG	:= -march=icelake-client
 endif
 
-BENCHOBJS	:= $(filter-out $(addprefix $(BENCHDIR)/, $(BENCHOBJS_SKIP)) ,$(BENCHOBJS))
-TESTOBJS	:= $(filter-out $(addprefix $(TESTDIR)/, $(TESTOBJS_SKIP)) ,$(TESTOBJS))
+BENCHOBJS	:= $(patsubst %.cpp, %.o, $(filter-out $(addprefix $(BENCHDIR)/, $(BENCHS_SKIP)), $(BENCHS)))
+TESTOBJS	:= $(patsubst %.cpp, %.o, $(filter-out $(addprefix $(TESTDIR)/, $(TESTS_SKIP)), $(TESTS)))
+UTILOBJS	:= $(UTILS:.cpp=.o)
 
-all : test bench
+# Stops make from wondering if it needs to generate the .hpp files (.cpp and .h have equivalent rules by default) 
+%.hpp:
 
-$(UTILS)/cpuinfo.o : $(UTILS)/cpuinfo.cpp
-	$(CXX) $(CXXFLAGS) -c $(UTILS)/cpuinfo.cpp -o $(UTILS)/cpuinfo.o
+.PHONY: all
+.DEFAULT_GOAL := all
+all: test bench
 
-$(TESTDIR)/%.o : $(TESTDIR)/%.cpp $(SRCS)
-	$(CXX) $(CXXFLAGS) $(MARCHFLAG) $(GTESTCFLAGS) -c $< -o $@
+.PHONY: test
+test: testexe
 
-test: $(TESTOBJS) $(UTILS)/cpuinfo.o $(SRCS)
-	$(CXX) $(TESTOBJS) $(UTILS)/cpuinfo.o $(MARCHFLAG) $(CXXFLAGS) -lgtest_main $(GTESTLDFLAGS) -o testexe
+.PHONY: bench
+bench: benchexe
 
-$(BENCHDIR)/%.o : $(BENCHDIR)/%.cpp $(SRCS)
-	$(CXX) $(CXXFLAGS) $(MARCHFLAG) $(GBENCHCFLAGS) -c $< -o $@
+$(UTILOBJS): $(UTILSRCS)
 
-bench: $(BENCHOBJS) $(UTILS)/cpuinfo.o
-	$(CXX) $(BENCHOBJS) $(UTILS)/cpuinfo.o $(MARCHFLAG) $(CXXFLAGS) -lbenchmark_main $(GBENCHLDFLAGS) -o benchexe
+$(TESTOBJS): $(TESTSRCS) $(UTILSRCS) $(SRCS)
+$(TESTDIR)/%.o: override CXXFLAGS += $(GTESTCFLAGS)
 
+testexe: $(TESTOBJS) $(UTILOBJS)
+	$(CXX) $(CXXFLAGS) $^ $(LDLIBS) $(LDFLAGS) -lgtest_main $(GTESTLDFLAGS) -o $@
+
+$(BENCHOBJS): $(BENCHSRCS) $(UTILSRCS) $(SRCS)
+$(BENCHDIR)/%.o: override CXXFLAGS += $(GBENCHCFLAGS)
+
+benchexe: $(BENCHOBJS) $(UTILOBJS)
+	$(CXX) $(CXXFLAGS) $^ $(LDLIBS) $(LDFLAGS) -lbenchmark_main $(GBENCHLDFLAGS) -o $@
+
+.PHONY: meson
 meson:
 	meson setup --warnlevel 0 --buildtype plain builddir
 	cd builddir && ninja
 
+.PHONY: clean
 clean:
-	$(RM) -rf $(TESTDIR)/*.o $(BENCHDIR)/*.o $(UTILS)/*.o testexe benchexe builddir
+	$(RM) -rf $(TESTOBJS) $(BENCHOBJS) $(UTILOBJS) testexe benchexe builddir

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-CXX		?= g++-12
+# When unset, discover g++. Prioritise the latest version on the path.
+ifeq (, $(and $(strip $(CXX)), $(filter-out default undefined, $(origin CXX))))
+  override CXX	:= $(shell basename `which g++-12 g++-11 g++-10 g++-9 g++-8 g++ | head -n 1`)
+endif
+
+export CXX
 CXXFLAGS	+= $(OPTIMFLAG) $(MARCHFLAG)
 override CXXFLAGS += -I$(SRCDIR) -I$(UTILSDIR)
 GTESTCFLAGS	:= `pkg-config --cflags gtest_main`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # When unset, discover g++. Prioritise the latest version on the path.
 ifeq (, $(and $(strip $(CXX)), $(filter-out default undefined, $(origin CXX))))
-  override CXX	:= $(shell basename `which g++-12 g++-11 g++-10 g++-9 g++-8 g++ | head -n 1`)
+  override CXX	:= $(shell which g++-12 g++-11 g++-10 g++-9 g++-8 g++ 2>/dev/null | head -n 1)
+  ifeq (, $(strip $(CXX)))
+    $(error Could not locate the g++ compiler. Please manually specify its path using the CXX variable)
+  endif
 endif
 
 export CXX


### PR DESCRIPTION
I am mostly using GNU make at the moment, so I eventually found a few other things I thought might be worth changing. Feel free to disagree, e.g. if you think some of the changes could make maintaining the file problematic in the future.

An overview of the commits:
1. 5041188: Improve modularity of GCC compatibility resolution
    - This uses a Makefile macro (`test_cxx_flag`) to allow checking an arbitrary flag of the GCC C++ compiler. AVX512-FP16 can be disabled without immediately falling back to `march=icelake-client`.
    - There is the potential to intelligently downgrade the target architecture further, but that might make removing the affected tests a bit more difficult (e.g. Could potentially handle this with preprocessor directives).
2. d0623a7: Substantially update Makefile to improve coverage
    - This commit makes significant changes to the design of the Makefile so that it is more sensitive to changes in the other files. Ultimately it's not as smart as meson when it comes to determining _which_ files need compilation, but with the current configuration it wouldn't detect that recompilation is needed when a header is changed inside the tests or benchmarks folders.
    - I opted to use the builtin implicit rules for compiling `.o` files that are found in prerequisites in order to reduce the number of rules and custom recipes. This mostly relies on stuffing all the options into `CXXFLAGS` instead.
    - I made the test and benchmark objects depend on the `.hpp` and `.h` files in their respective folders, too. This is in addition to their dependence on the files in the src and utils directories. This fits within the new approach by using rules to modify the compiler flags depending on which folder the target resides in.
    - Designated the targets that do not produce a file (with the same name as the rule's target) as phony to ensure they can always be run as expected.
    - Giving consideration to the potential for a user to override `CXXFLAGS`, the critical changes are now made in an override clause. I also swapped the variables from recursively expanded to simple where it was possible.
3. 18d036f: Robustify CXX detection logic
    - The conditional assignment on the first line of the Makefile seems like it will actually never fire because `CXX` holds `g++` by default.
    - Therefore, I've added some new checks to (attempt to) intelligently detect and set the `CXX` variable when the user hasn't already done so. The detected version will also propagate to meson when that is the target.
4. c0a99e0 (bugfix for 18d036f): Silence GCC discovery and bail when none available
    - On some systems, `which` will print to stderr when an argument can't be found. This will now be suppressed.
    - Also removed `basename` to more gracefully handle the situation where `g++` is not on the path.