### PR TITLE
Update workflow for changes in benchmark tooling

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         git clone https://github.com/google/benchmark.git
         cd benchmark
-        pip3 install -r requirements.txt
+        pip3 install -r tools/requirements.txt
         cmake -E make_directory "build"
         cmake -E chdir "build" cmake -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ../
         sudo cmake --build "build" --config Release --target install


### PR DESCRIPTION
Google's Benchmark project has rearranged some of the files we need for the testing workflows. This commit points pip towards to correct requirements.txt for the latest versions of the framework. Alternatively, we could use `-b <name>` to ensure we always use the same version of the benchmark dependency.

```diff
mosullivan@melchior:~/source/repos/googlebenchmarks> git diff v1.8.0:requirements.txt HEAD:tools/requirements.txt
diff --git a/requirements.txt b/tools/requirements.txt
index 1c8a4bd..afbc596 100644
--- a/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
-numpy == 1.22
+numpy == 1.25
 scipy == 1.5.4
```