### PR TITLE
Expose avx512_qsort functions to C programs

### DIFF
--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -469,4 +469,19 @@ void avx512_qsort_fp16(uint16_t *arr, int64_t arrsize)
     }
 }
 
+extern "C" {
+    void int16_avx512_qsort(int16_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<int16_t>(arr, arrsize);
+    }
+    void uint16_avx512_qsort(uint16_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<uint16_t>(arr, arrsize);
+    }
+    void float16_avx512_qsort(uint16_t* arr, int64_t arrsize)
+    {
+        avx512_qsort_fp16(arr, arrsize);
+    }
+}
+
 #endif // AVX512_QSORT_16BIT

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -774,4 +774,19 @@ void avx512_qsort<float>(float *arr, int64_t arrsize)
     }
 }
 
+extern "C" {
+    void int32_avx512_qsort(int32_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<int32_t>(arr, arrsize);
+    }
+    void uint32_avx512_qsort(uint32_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<uint32_t>(arr, arrsize);
+    }
+    void float_avx512_qsort(float* arr, int64_t arrsize)
+    {
+        avx512_qsort<float>(arr, arrsize);
+    }
+}
+
 #endif //AVX512_QSORT_32BIT

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -842,4 +842,20 @@ void avx512_qsort<double>(double *arr, int64_t arrsize)
         replace_inf_with_nan(arr, arrsize, nan_count);
     }
 }
+
+extern "C" {
+    void int64_avx512_qsort(int64_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<int64_t>(arr, arrsize);
+    }
+    void uint64_avx512_qsort(uint64_t* arr, int64_t arrsize)
+    {
+        avx512_qsort<uint64_t>(arr, arrsize);
+    }
+    void double_avx512_qsort(double* arr, int64_t arrsize)
+    {
+        avx512_qsort<double>(arr, arrsize);
+    }
+}
+
 #endif // AVX512_QSORT_64BIT


### PR DESCRIPTION
Build and use `avx512_qsort `in a C program using the following C functions: 

```
void int16_avx512_qsort(int16_t* arr, int64_t arrsize)
void uint16_avx512_qsort(uint16_t* arr, int64_t arrsize)
void float16_avx512_qsort(uint16_t* arr, int64_t arrsize)
void int32_avx512_qsort(int32_t* arr, int64_t arrsize)
void uint32_avx512_qsort(uint32_t* arr, int64_t arrsize)
void float_avx512_qsort(float* arr, int64_t arrsize)
void int64_avx512_qsort(int64_t* arr, int64_t arrsize)
void uint64_avx512_qsort(uint64_t* arr, int64_t arrsize)
void double_avx512_qsort(double* arr, int64_t arrsize)
```


Example `main.c`: 
```

#include <stdint.h>
void double_avx512_qsort(double*, int64_t);

int main() {
    const int ARRSIZE = 1000;
    double arr[ARRSIZE];

    /* Initialize elements is reverse order */
    for (int ii = 0; ii < ARRSIZE; ++ii) {
        arr[ii] = ARRSIZE - ii;
    }

    /* call avx512 quicksort */
    double_avx512_qsort(arr, ARRSIZE);
    return 0;
}

```

Steps to build: 

```
g++ -c -fpic -x c++ avx512-64bit-qsort.hpp -o avx512qsort.o -march=skylake-avx512 -O3
gcc main.c avx512qsort.o -lm
```