### PR TITLE
MAINT: Remove template specializations for quicksort methods

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('x86-simd-sort', 'cpp',
-        version : '1.0.0',
-        license : 'BSD 3-clause')
+        version : '2.0.0',
+        license : 'BSD 3-clause',
+        default_options : ['cpp_std=c++17'])
 cpp = meson.get_compiler('cpp')
 src = include_directories('src')
 bench = include_directories('benchmarks')

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -377,9 +377,9 @@ bool comparison_func<zmm_vector<float16>>(const uint16_t &a, const uint16_t &b)
     //return npy_half_to_float(a) < npy_half_to_float(b);
 }
 
-template<>
-int64_t
-replace_nan_with_inf<zmm_vector<float16>>(uint16_t *arr, int64_t arrsize)
+template <>
+int64_t replace_nan_with_inf<zmm_vector<float16>>(uint16_t *arr,
+                                                  int64_t arrsize)
 {
     int64_t nan_count = 0;
     __mmask16 loadmask = 0xFFFF;
@@ -405,13 +405,19 @@ bool is_a_nan<uint16_t>(uint16_t elem)
 
 /* Specialized template function for 16-bit qsort_ funcs*/
 template <>
-void qsort_<zmm_vector<int16_t>>(int16_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<int16_t>>(int16_t *arr,
+                                 int64_t left,
+                                 int64_t right,
+                                 int64_t maxiters)
 {
     qsort_16bit_<zmm_vector<int16_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void qsort_<zmm_vector<uint16_t>>(uint16_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<uint16_t>>(uint16_t *arr,
+                                  int64_t left,
+                                  int64_t right,
+                                  int64_t maxiters)
 {
     qsort_16bit_<zmm_vector<uint16_t>>(arr, left, right, maxiters);
 }
@@ -419,7 +425,8 @@ void qsort_<zmm_vector<uint16_t>>(uint16_t* arr, int64_t left, int64_t right, in
 void avx512_qsort_fp16(uint16_t *arr, int64_t arrsize)
 {
     if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf<zmm_vector<float16>, uint16_t>(arr, arrsize);
+        int64_t nan_count = replace_nan_with_inf<zmm_vector<float16>, uint16_t>(
+                arr, arrsize);
         qsort_16bit_<zmm_vector<float16>, uint16_t>(
                 arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
         replace_inf_with_nan(arr, arrsize, nan_count);
@@ -428,13 +435,15 @@ void avx512_qsort_fp16(uint16_t *arr, int64_t arrsize)
 
 /* Specialized template function for 16-bit qselect_ funcs*/
 template <>
-void qselect_<zmm_vector<int16_t>>(int16_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<int16_t>>(
+        int16_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_16bit_<zmm_vector<int16_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void qselect_<zmm_vector<uint16_t>>(uint16_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<uint16_t>>(
+        uint16_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_16bit_<zmm_vector<uint16_t>>(arr, k, left, right, maxiters);
 }

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -256,6 +256,10 @@ struct zmm_vector<float> {
     {
         return _mm512_cmp_ps_mask(x, y, _CMP_GE_OQ);
     }
+    static opmask_t get_partial_loadmask(int size)
+    {
+        return (0x0001 << size) - 0x0001;
+    }
     template <int type>
     static opmask_t fpclass(zmm_t x)
     {

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -704,38 +704,50 @@ static void qselect_32bit_(type_t *arr,
 
 /* Specialized template function for 32-bit qselect_ funcs*/
 template <>
-void qselect_<zmm_vector<int32_t>>(int32_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<int32_t>>(
+        int32_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_32bit_<zmm_vector<int32_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void qselect_<zmm_vector<uint32_t>>(uint32_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<uint32_t>>(
+        uint32_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_32bit_<zmm_vector<uint32_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void qselect_<zmm_vector<float>>(float* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<float>>(
+        float *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_32bit_<zmm_vector<float>>(arr, k, left, right, maxiters);
 }
 
 /* Specialized template function for 32-bit qsort_ funcs*/
 template <>
-void qsort_<zmm_vector<int32_t>>(int32_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<int32_t>>(int32_t *arr,
+                                 int64_t left,
+                                 int64_t right,
+                                 int64_t maxiters)
 {
     qsort_32bit_<zmm_vector<int32_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void qsort_<zmm_vector<uint32_t>>(uint32_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<uint32_t>>(uint32_t *arr,
+                                  int64_t left,
+                                  int64_t right,
+                                  int64_t maxiters)
 {
     qsort_32bit_<zmm_vector<uint32_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void qsort_<zmm_vector<float>>(float* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<float>>(float *arr,
+                               int64_t left,
+                               int64_t right,
+                               int64_t maxiters)
 {
     qsort_32bit_<zmm_vector<float>>(arr, left, right, maxiters);
 }

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -702,43 +702,26 @@ static void qselect_32bit_(type_t *arr,
         qselect_32bit_<vtype>(arr, pos, pivot_index, right, max_iters - 1);
 }
 
+/* Specialized template function for 32-bit qselect_ funcs*/
 template <>
-void avx512_qselect<int32_t>(int32_t *arr,
-                             int64_t k,
-                             int64_t arrsize,
-                             bool hasnan)
+void qselect_<zmm_vector<int32_t>>(int32_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qselect_32bit_<zmm_vector<int32_t>, int32_t>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qselect_32bit_<zmm_vector<int32_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void avx512_qselect<uint32_t>(uint32_t *arr,
-                              int64_t k,
-                              int64_t arrsize,
-                              bool hasnan)
+void qselect_<zmm_vector<uint32_t>>(uint32_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qselect_32bit_<zmm_vector<uint32_t>, uint32_t>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qselect_32bit_<zmm_vector<uint32_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void avx512_qselect<float>(float *arr, int64_t k, int64_t arrsize, bool hasnan)
+void qselect_<zmm_vector<float>>(float* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    int64_t indx_last_elem = arrsize - 1;
-    if (UNLIKELY(hasnan)) {
-        indx_last_elem = move_nans_to_end_of_array(arr, arrsize);
-    }
-    if (indx_last_elem >= k) {
-        qselect_32bit_<zmm_vector<float>, float>(
-                arr, k, 0, indx_last_elem, 2 * (int64_t)log2(indx_last_elem));
-    }
+    qselect_32bit_<zmm_vector<float>>(arr, k, left, right, maxiters);
 }
 
+/* Specialized template function for 32-bit qsort_ funcs*/
 template <>
 void qsort_<zmm_vector<int32_t>>(int32_t* arr, int64_t left, int64_t right, int64_t maxiters)
 {

--- a/src/avx512-64bit-argsort.hpp
+++ b/src/avx512-64bit-argsort.hpp
@@ -344,33 +344,6 @@ static void argselect_64bit_(type_t *arr,
                 arr, arg, pos, pivot_index, right, max_iters - 1);
 }
 
-template <typename vtype, typename type_t>
-bool has_nan(type_t *arr, int64_t arrsize)
-{
-    using opmask_t = typename vtype::opmask_t;
-    using zmm_t = typename vtype::zmm_t;
-    bool found_nan = false;
-    opmask_t loadmask = 0xFF;
-    zmm_t in;
-    while (arrsize > 0) {
-        if (arrsize < vtype::numlanes) {
-            loadmask = (0x01 << arrsize) - 0x01;
-            in = vtype::maskz_loadu(loadmask, arr);
-        }
-        else {
-            in = vtype::loadu(arr);
-        }
-        opmask_t nanmask = vtype::template fpclass<0x01 | 0x80>(in);
-        arr += vtype::numlanes;
-        arrsize -= vtype::numlanes;
-        if (nanmask != 0x00) {
-            found_nan = true;
-            break;
-        }
-    }
-    return found_nan;
-}
-
 /* argsort methods for 32-bit and 64-bit dtypes */
 template <typename T>
 void avx512_argsort(T *arr, int64_t *arg, int64_t arrsize)

--- a/src/avx512-64bit-argsort.hpp
+++ b/src/avx512-64bit-argsort.hpp
@@ -427,15 +427,6 @@ void avx512_argsort(float *arr, int64_t *arg, int64_t arrsize)
     }
 }
 
-template <typename T>
-std::vector<int64_t> avx512_argsort(T *arr, int64_t arrsize)
-{
-    std::vector<int64_t> indices(arrsize);
-    std::iota(indices.begin(), indices.end(), 0);
-    avx512_argsort<T>(arr, indices.data(), arrsize);
-    return indices;
-}
-
 /* argselect methods for 32-bit and 64-bit dtypes */
 template <typename T>
 void avx512_argselect(T *arr, int64_t *arg, int64_t k, int64_t arrsize)
@@ -492,13 +483,5 @@ void avx512_argselect(float *arr, int64_t *arg, int64_t k, int64_t arrsize)
     }
 }
 
-template <typename T>
-std::vector<int64_t> avx512_argselect(T *arr, int64_t k, int64_t arrsize)
-{
-    std::vector<int64_t> indices(arrsize);
-    std::iota(indices.begin(), indices.end(), 0);
-    avx512_argselect<T>(arr, indices.data(), k, arrsize);
-    return indices;
-}
 
 #endif // AVX512_ARGSORT_64BIT

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -40,14 +40,8 @@ struct ymm_vector<float> {
         return _mm256_set1_ps(type_max());
     }
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm256_set_epi32(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -93,7 +87,7 @@ struct ymm_vector<float> {
     }
     static zmm_t loadu(void const *mem)
     {
-        return _mm256_loadu_ps((float*) mem);
+        return _mm256_loadu_ps((float *)mem);
     }
     static zmm_t max(zmm_t x, zmm_t y)
     {
@@ -129,16 +123,22 @@ struct ymm_vector<float> {
     }
     static type_t reducemax(zmm_t v)
     {
-        __m128 v128 = _mm_max_ps(_mm256_castps256_ps128(v), _mm256_extractf32x4_ps (v, 1));
-        __m128 v64 =  _mm_max_ps(v128, _mm_shuffle_ps(v128, v128, _MM_SHUFFLE(1, 0, 3, 2)));
-        __m128 v32 = _mm_max_ps(v64, _mm_shuffle_ps(v64, v64, _MM_SHUFFLE(0, 0, 0, 1)));
+        __m128 v128 = _mm_max_ps(_mm256_castps256_ps128(v),
+                                 _mm256_extractf32x4_ps(v, 1));
+        __m128 v64 = _mm_max_ps(
+                v128, _mm_shuffle_ps(v128, v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128 v32 = _mm_max_ps(
+                v64, _mm_shuffle_ps(v64, v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return _mm_cvtss_f32(v32);
     }
     static type_t reducemin(zmm_t v)
     {
-        __m128 v128 = _mm_min_ps(_mm256_castps256_ps128(v), _mm256_extractf32x4_ps(v, 1));
-        __m128 v64 =  _mm_min_ps(v128, _mm_shuffle_ps(v128, v128,_MM_SHUFFLE(1, 0, 3, 2)));
-        __m128 v32 = _mm_min_ps(v64, _mm_shuffle_ps(v64, v64,_MM_SHUFFLE(0, 0, 0, 1)));
+        __m128 v128 = _mm_min_ps(_mm256_castps256_ps128(v),
+                                 _mm256_extractf32x4_ps(v, 1));
+        __m128 v64 = _mm_min_ps(
+                v128, _mm_shuffle_ps(v128, v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128 v32 = _mm_min_ps(
+                v64, _mm_shuffle_ps(v64, v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return _mm_cvtss_f32(v32);
     }
     static zmm_t set1(type_t v)
@@ -160,7 +160,7 @@ struct ymm_vector<float> {
     }
     static void storeu(void *mem, zmm_t x)
     {
-        _mm256_storeu_ps((float*)mem, x);
+        _mm256_storeu_ps((float *)mem, x);
     }
 };
 template <>
@@ -184,14 +184,8 @@ struct ymm_vector<uint32_t> {
         return _mm256_set1_epi32(type_max());
     }
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm256_set_epi32(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -228,7 +222,7 @@ struct ymm_vector<uint32_t> {
     }
     static zmm_t loadu(void const *mem)
     {
-        return _mm256_loadu_si256((__m256i*) mem);
+        return _mm256_loadu_si256((__m256i *)mem);
     }
     static zmm_t max(zmm_t x, zmm_t y)
     {
@@ -264,16 +258,22 @@ struct ymm_vector<uint32_t> {
     }
     static type_t reducemax(zmm_t v)
     {
-        __m128i v128 = _mm_max_epu32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
-        __m128i v64 =  _mm_max_epu32(v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
-        __m128i v32 = _mm_max_epu32(v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
+        __m128i v128 = _mm_max_epu32(_mm256_castsi256_si128(v),
+                                     _mm256_extracti128_si256(v, 1));
+        __m128i v64 = _mm_max_epu32(
+                v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128i v32 = _mm_max_epu32(
+                v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return (type_t)_mm_cvtsi128_si32(v32);
     }
     static type_t reducemin(zmm_t v)
     {
-        __m128i v128 = _mm_min_epu32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
-        __m128i v64 =  _mm_min_epu32(v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
-        __m128i v32 = _mm_min_epu32(v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
+        __m128i v128 = _mm_min_epu32(_mm256_castsi256_si128(v),
+                                     _mm256_extracti128_si256(v, 1));
+        __m128i v64 = _mm_min_epu32(
+                v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128i v32 = _mm_min_epu32(
+                v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return (type_t)_mm_cvtsi128_si32(v32);
     }
     static zmm_t set1(type_t v)
@@ -289,7 +289,7 @@ struct ymm_vector<uint32_t> {
     }
     static void storeu(void *mem, zmm_t x)
     {
-        _mm256_storeu_si256((__m256i*) mem, x);
+        _mm256_storeu_si256((__m256i *)mem, x);
     }
 };
 template <>
@@ -313,14 +313,8 @@ struct ymm_vector<int32_t> {
         return _mm256_set1_epi32(type_max());
     } // TODO: this should broadcast bits as is?
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm256_set_epi32(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -357,7 +351,7 @@ struct ymm_vector<int32_t> {
     }
     static zmm_t loadu(void const *mem)
     {
-        return _mm256_loadu_si256((__m256i*) mem);
+        return _mm256_loadu_si256((__m256i *)mem);
     }
     static zmm_t max(zmm_t x, zmm_t y)
     {
@@ -393,16 +387,22 @@ struct ymm_vector<int32_t> {
     }
     static type_t reducemax(zmm_t v)
     {
-        __m128i v128 = _mm_max_epi32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
-        __m128i v64 =  _mm_max_epi32(v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
-        __m128i v32 = _mm_max_epi32(v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
+        __m128i v128 = _mm_max_epi32(_mm256_castsi256_si128(v),
+                                     _mm256_extracti128_si256(v, 1));
+        __m128i v64 = _mm_max_epi32(
+                v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128i v32 = _mm_max_epi32(
+                v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return (type_t)_mm_cvtsi128_si32(v32);
     }
     static type_t reducemin(zmm_t v)
     {
-        __m128i v128 = _mm_min_epi32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
-        __m128i v64 =  _mm_min_epi32(v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
-        __m128i v32 = _mm_min_epi32(v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
+        __m128i v128 = _mm_min_epi32(_mm256_castsi256_si128(v),
+                                     _mm256_extracti128_si256(v, 1));
+        __m128i v64 = _mm_min_epi32(
+                v128, _mm_shuffle_epi32(v128, _MM_SHUFFLE(1, 0, 3, 2)));
+        __m128i v32 = _mm_min_epi32(
+                v64, _mm_shuffle_epi32(v64, _MM_SHUFFLE(0, 0, 0, 1)));
         return (type_t)_mm_cvtsi128_si32(v32);
     }
     static zmm_t set1(type_t v)
@@ -418,7 +418,7 @@ struct ymm_vector<int32_t> {
     }
     static void storeu(void *mem, zmm_t x)
     {
-        _mm256_storeu_si256((__m256i*) mem, x);
+        _mm256_storeu_si256((__m256i *)mem, x);
     }
 };
 template <>
@@ -443,14 +443,8 @@ struct zmm_vector<int64_t> {
         return _mm512_set1_epi64(type_max());
     } // TODO: this should broadcast bits as is?
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm512_set_epi64(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -567,14 +561,8 @@ struct zmm_vector<uint64_t> {
         return _mm512_set1_epi64(type_max());
     }
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm512_set_epi64(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -679,14 +667,8 @@ struct zmm_vector<double> {
         return _mm512_set1_pd(type_max());
     }
 
-    static zmmi_t seti(int v1,
-                       int v2,
-                       int v3,
-                       int v4,
-                       int v5,
-                       int v6,
-                       int v7,
-                       int v8)
+    static zmmi_t
+    seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
         return _mm512_set_epi64(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -793,16 +775,12 @@ X86_SIMD_SORT_INLINE zmm_t sort_zmm_64bit(zmm_t zmm)
     zmm = cmp_merge<vtype>(
             zmm, vtype::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(zmm), 0xAA);
     zmm = cmp_merge<vtype>(
-            zmm,
-            vtype::permutexvar(vtype::seti(NETWORK_64BIT_1), zmm),
-            0xCC);
+            zmm, vtype::permutexvar(vtype::seti(NETWORK_64BIT_1), zmm), 0xCC);
     zmm = cmp_merge<vtype>(
             zmm, vtype::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(zmm), 0xAA);
     zmm = cmp_merge<vtype>(zmm, vtype::permutexvar(rev_index, zmm), 0xF0);
     zmm = cmp_merge<vtype>(
-            zmm,
-            vtype::permutexvar(vtype::seti(NETWORK_64BIT_3), zmm),
-            0xCC);
+            zmm, vtype::permutexvar(vtype::seti(NETWORK_64BIT_3), zmm), 0xCC);
     zmm = cmp_merge<vtype>(
             zmm, vtype::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(zmm), 0xAA);
     return zmm;

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -773,30 +773,7 @@ struct zmm_vector<double> {
         _mm512_storeu_pd(mem, x);
     }
 };
-X86_SIMD_SORT_INLINE int64_t replace_nan_with_inf(double *arr, int64_t arrsize)
-{
-    int64_t nan_count = 0;
-    __mmask8 loadmask = 0xFF;
-    while (arrsize > 0) {
-        if (arrsize < 8) { loadmask = (0x01 << arrsize) - 0x01; }
-        __m512d in_zmm = _mm512_maskz_loadu_pd(loadmask, arr);
-        __mmask8 nanmask = _mm512_cmp_pd_mask(in_zmm, in_zmm, _CMP_NEQ_UQ);
-        nan_count += _mm_popcnt_u32((int32_t)nanmask);
-        _mm512_mask_storeu_pd(arr, nanmask, ZMM_MAX_DOUBLE);
-        arr += 8;
-        arrsize -= 8;
-    }
-    return nan_count;
-}
 
-X86_SIMD_SORT_INLINE void
-replace_inf_with_nan(double *arr, int64_t arrsize, int64_t nan_count)
-{
-    for (int64_t ii = arrsize - 1; nan_count > 0; --ii) {
-        arr[ii] = std::nan("1");
-        nan_count -= 1;
-    }
-}
 /*
  * Assumes zmm is random and performs a full sorting network defined in
  * https://en.wikipedia.org/wiki/Bitonic_sorter#/media/File:BitonicSort.svg

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -71,6 +71,10 @@ struct ymm_vector<float> {
     {
         return _mm256_cmp_ps_mask(x, y, _CMP_EQ_OQ);
     }
+    static opmask_t get_partial_loadmask(int size)
+    {
+        return (0x01 << size) - 0x01;
+    }
     template <int type>
     static opmask_t fpclass(zmm_t x)
     {
@@ -702,6 +706,10 @@ struct zmm_vector<double> {
     static opmask_t eq(zmm_t x, zmm_t y)
     {
         return _mm512_cmp_pd_mask(x, y, _CMP_EQ_OQ);
+    }
+    static opmask_t get_partial_loadmask(int size)
+    {
+        return (0x01 << size) - 0x01;
     }
     template <int type>
     static opmask_t fpclass(zmm_t x)

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -444,7 +444,8 @@ void avx512_qsort_kv(T1 *keys, T2 *indexes, int64_t arrsize)
 {
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T1>) {
-            int64_t nan_count = replace_nan_with_inf<zmm_vector<double>>(keys, arrsize);
+            int64_t nan_count
+                    = replace_nan_with_inf<zmm_vector<double>>(keys, arrsize);
             qsort_64bit_<zmm_vector<T1>, zmm_vector<T2>>(
                     keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
             replace_inf_with_nan(keys, arrsize, nan_count);

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -463,7 +463,7 @@ template <>
 void avx512_qsort_kv<double>(double *keys, uint64_t *indexes, int64_t arrsize)
 {
     if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf(keys, arrsize);
+        int64_t nan_count = replace_nan_with_inf<zmm_vector<double>>(keys, arrsize);
         qsort_64bit_<zmm_vector<double>, zmm_vector<uint64_t>>(
                 keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
         replace_inf_with_nan(keys, arrsize, nan_count);

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -439,34 +439,20 @@ void qsort_64bit_(type1_t *keys,
     }
 }
 
-template <>
-void avx512_qsort_kv<int64_t>(int64_t *keys, uint64_t *indexes, int64_t arrsize)
+template <typename T1, typename T2>
+void avx512_qsort_kv(T1 *keys, T2 *indexes, int64_t arrsize)
 {
     if (arrsize > 1) {
-        qsort_64bit_<zmm_vector<int64_t>, zmm_vector<uint64_t>>(
-                keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
-}
-
-template <>
-void avx512_qsort_kv<uint64_t>(uint64_t *keys,
-                               uint64_t *indexes,
-                               int64_t arrsize)
-{
-    if (arrsize > 1) {
-        qsort_64bit_<zmm_vector<uint64_t>, zmm_vector<uint64_t>>(
-                keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
-}
-
-template <>
-void avx512_qsort_kv<double>(double *keys, uint64_t *indexes, int64_t arrsize)
-{
-    if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf<zmm_vector<double>>(keys, arrsize);
-        qsort_64bit_<zmm_vector<double>, zmm_vector<uint64_t>>(
-                keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-        replace_inf_with_nan(keys, arrsize, nan_count);
+        if constexpr (std::is_floating_point_v<T1>) {
+            int64_t nan_count = replace_nan_with_inf<zmm_vector<double>>(keys, arrsize);
+            qsort_64bit_<zmm_vector<T1>, zmm_vector<T2>>(
+                    keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
+            replace_inf_with_nan(keys, arrsize, nan_count);
+        }
+        else {
+            qsort_64bit_<zmm_vector<T1>, zmm_vector<T2>>(
+                    keys, indexes, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
+        }
     }
 }
 #endif // AVX512_QSORT_64BIT_KV

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -824,31 +824,20 @@ void avx512_qselect<double>(double *arr,
 }
 
 template <>
-void avx512_qsort<int64_t>(int64_t *arr, int64_t arrsize)
+void qsort_<zmm_vector<int64_t>>(int64_t* arr, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qsort_64bit_<zmm_vector<int64_t>, int64_t>(
-                arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qsort_64bit_<zmm_vector<int64_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void avx512_qsort<uint64_t>(uint64_t *arr, int64_t arrsize)
+void qsort_<zmm_vector<uint64_t>>(uint64_t* arr, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qsort_64bit_<zmm_vector<uint64_t>, uint64_t>(
-                arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qsort_64bit_<zmm_vector<uint64_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void avx512_qsort<double>(double *arr, int64_t arrsize)
+void qsort_<zmm_vector<double>>(double* arr, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf(arr, arrsize);
-        qsort_64bit_<zmm_vector<double>, double>(
-                arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-        replace_inf_with_nan(arr, arrsize, nan_count);
-    }
+    qsort_64bit_<zmm_vector<double>>(arr, left, right, maxiters);
 }
 #endif // AVX512_QSORT_64BIT

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -785,38 +785,50 @@ static void qselect_64bit_(type_t *arr,
 
 /* Specialized template function for 64-bit qselect_ funcs*/
 template <>
-void qselect_<zmm_vector<int64_t>>(int64_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<int64_t>>(
+        int64_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_64bit_<zmm_vector<int64_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void qselect_<zmm_vector<uint64_t>>(uint64_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<uint64_t>>(
+        uint64_t *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_64bit_<zmm_vector<uint64_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void qselect_<zmm_vector<double>>(double* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<double>>(
+        double *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_64bit_<zmm_vector<double>>(arr, k, left, right, maxiters);
 }
 
 /* Specialized template function for 64-bit qsort_ funcs*/
 template <>
-void qsort_<zmm_vector<int64_t>>(int64_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<int64_t>>(int64_t *arr,
+                                 int64_t left,
+                                 int64_t right,
+                                 int64_t maxiters)
 {
     qsort_64bit_<zmm_vector<int64_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void qsort_<zmm_vector<uint64_t>>(uint64_t* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<uint64_t>>(uint64_t *arr,
+                                  int64_t left,
+                                  int64_t right,
+                                  int64_t maxiters)
 {
     qsort_64bit_<zmm_vector<uint64_t>>(arr, left, right, maxiters);
 }
 
 template <>
-void qsort_<zmm_vector<double>>(double* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<double>>(double *arr,
+                                int64_t left,
+                                int64_t right,
+                                int64_t maxiters)
 {
     qsort_64bit_<zmm_vector<double>>(arr, left, right, maxiters);
 }

--- a/src/avx512-64bit-qsort.hpp
+++ b/src/avx512-64bit-qsort.hpp
@@ -783,46 +783,26 @@ static void qselect_64bit_(type_t *arr,
         qselect_64bit_<vtype>(arr, pos, pivot_index, right, max_iters - 1);
 }
 
+/* Specialized template function for 64-bit qselect_ funcs*/
 template <>
-void avx512_qselect<int64_t>(int64_t *arr,
-                             int64_t k,
-                             int64_t arrsize,
-                             bool hasnan)
+void qselect_<zmm_vector<int64_t>>(int64_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qselect_64bit_<zmm_vector<int64_t>, int64_t>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qselect_64bit_<zmm_vector<int64_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void avx512_qselect<uint64_t>(uint64_t *arr,
-                              int64_t k,
-                              int64_t arrsize,
-                              bool hasnan)
+void qselect_<zmm_vector<uint64_t>>(uint64_t* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        qselect_64bit_<zmm_vector<uint64_t>, uint64_t>(
-                arr, k, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-    }
+    qselect_64bit_<zmm_vector<uint64_t>>(arr, k, left, right, maxiters);
 }
 
 template <>
-void avx512_qselect<double>(double *arr,
-                            int64_t k,
-                            int64_t arrsize,
-                            bool hasnan)
+void qselect_<zmm_vector<double>>(double* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
-    int64_t indx_last_elem = arrsize - 1;
-    if (UNLIKELY(hasnan)) {
-        indx_last_elem = move_nans_to_end_of_array(arr, arrsize);
-    }
-    if (indx_last_elem >= k) {
-        qselect_64bit_<zmm_vector<double>, double>(
-                arr, k, 0, indx_last_elem, 2 * (int64_t)log2(indx_last_elem));
-    }
+    qselect_64bit_<zmm_vector<double>>(arr, k, left, right, maxiters);
 }
 
+/* Specialized template function for 64-bit qsort_ funcs*/
 template <>
 void qsort_<zmm_vector<int64_t>>(int64_t* arr, int64_t left, int64_t right, int64_t maxiters)
 {

--- a/src/avx512-common-argsort.h
+++ b/src/avx512-common-argsort.h
@@ -19,13 +19,26 @@ template <typename T>
 void avx512_argsort(T *arr, int64_t *arg, int64_t arrsize);
 
 template <typename T>
-std::vector<int64_t> avx512_argsort(T *arr, int64_t arrsize);
-
-template <typename T>
 void avx512_argselect(T *arr, int64_t *arg, int64_t k, int64_t arrsize);
 
 template <typename T>
-std::vector<int64_t> avx512_argselect(T *arr, int64_t k, int64_t arrsize);
+std::vector<int64_t> avx512_argsort(T *arr, int64_t arrsize)
+{
+    std::vector<int64_t> indices(arrsize);
+    std::iota(indices.begin(), indices.end(), 0);
+    avx512_argsort<T>(arr, indices.data(), arrsize);
+    return indices;
+}
+
+template <typename T>
+std::vector<int64_t> avx512_argselect(T *arr, int64_t k, int64_t arrsize)
+{
+    std::vector<int64_t> indices(arrsize);
+    std::iota(indices.begin(), indices.end(), 0);
+    avx512_argselect<T>(arr, indices.data(), k, arrsize);
+    return indices;
+}
+
 /*
  * Parition one ZMM register based on the pivot and returns the index of the
  * last element that is less than equal to the pivot.

--- a/src/avx512-common-argsort.h
+++ b/src/avx512-common-argsort.h
@@ -15,30 +15,6 @@
 using argtype = zmm_vector<int64_t>;
 using argzmm_t = typename argtype::zmm_t;
 
-template <typename T>
-void avx512_argsort(T *arr, int64_t *arg, int64_t arrsize);
-
-template <typename T>
-void avx512_argselect(T *arr, int64_t *arg, int64_t k, int64_t arrsize);
-
-template <typename T>
-std::vector<int64_t> avx512_argsort(T *arr, int64_t arrsize)
-{
-    std::vector<int64_t> indices(arrsize);
-    std::iota(indices.begin(), indices.end(), 0);
-    avx512_argsort<T>(arr, indices.data(), arrsize);
-    return indices;
-}
-
-template <typename T>
-std::vector<int64_t> avx512_argselect(T *arr, int64_t k, int64_t arrsize)
-{
-    std::vector<int64_t> indices(arrsize);
-    std::iota(indices.begin(), indices.end(), 0);
-    avx512_argselect<T>(arr, indices.data(), k, arrsize);
-    return indices;
-}
-
 /*
  * Parition one ZMM register based on the pivot and returns the index of the
  * last element that is less than equal to the pivot.

--- a/src/avx512-common-argsort.h
+++ b/src/avx512-common-argsort.h
@@ -34,7 +34,8 @@ static inline int32_t partition_vec(type_t *arg,
     int32_t amount_gt_pivot = _mm_popcnt_u32((int32_t)gt_mask);
     argtype::mask_compressstoreu(
             arg + left, vtype::knot_opmask(gt_mask), arg_vec);
-    argtype::mask_compressstoreu(arg + right - amount_gt_pivot, gt_mask, arg_vec);
+    argtype::mask_compressstoreu(
+            arg + right - amount_gt_pivot, gt_mask, arg_vec);
     *smallest_vec = vtype::min(curr_vec, *smallest_vec);
     *biggest_vec = vtype::max(curr_vec, *biggest_vec);
     return amount_gt_pivot;
@@ -225,7 +226,8 @@ static inline int64_t partition_avx512_unrolled(type_t *arr,
             right -= num_unroll * vtype::numlanes;
 #pragma GCC unroll 8
             for (int ii = 0; ii < num_unroll; ++ii) {
-                arg_vec[ii] = argtype::loadu(arg + right + ii * vtype::numlanes);
+                arg_vec[ii]
+                        = argtype::loadu(arg + right + ii * vtype::numlanes);
                 curr_vec[ii] = vtype::template i64gather<sizeof(type_t)>(
                         arg_vec[ii], arr);
             }

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -85,8 +85,8 @@
 #define X86_SIMD_SORT_FINLINE static
 #endif
 
-#define LIKELY(x)       __builtin_expect((x),1)
-#define UNLIKELY(x)     __builtin_expect((x),0)
+#define LIKELY(x) __builtin_expect((x), 1)
+#define UNLIKELY(x) __builtin_expect((x), 0)
 
 template <typename type>
 struct zmm_vector;
@@ -152,7 +152,7 @@ bool has_nan(type_t *arr, int64_t arrsize)
     return found_nan;
 }
 
-template<typename type_t>
+template <typename type_t>
 void replace_inf_with_nan(type_t *arr, int64_t arrsize, int64_t nan_count)
 {
     for (int64_t ii = arrsize - 1; nan_count > 0; --ii) {
@@ -171,7 +171,7 @@ void replace_inf_with_nan(type_t *arr, int64_t arrsize, int64_t nan_count)
  * in the array which is not a nan
  */
 template <typename T>
-int64_t move_nans_to_end_of_array(T* arr, int64_t arrsize)
+int64_t move_nans_to_end_of_array(T *arr, int64_t arrsize)
 {
     int64_t jj = arrsize - 1;
     int64_t ii = 0;
@@ -186,7 +186,7 @@ int64_t move_nans_to_end_of_array(T* arr, int64_t arrsize)
             ii += 1;
         }
     }
-    return arrsize-count-1;
+    return arrsize - count - 1;
 }
 
 template <typename vtype, typename T = typename vtype::type_t>
@@ -671,10 +671,14 @@ static inline int64_t partition_avx512(type_t1 *keys,
 }
 
 template <typename vtype, typename type_t>
-void qsort_(type_t* arr, int64_t left, int64_t right, int64_t maxiters);
+void qsort_(type_t *arr, int64_t left, int64_t right, int64_t maxiters);
 
 template <typename vtype, typename type_t>
-void qselect_(type_t* arr, int64_t pos, int64_t left, int64_t right, int64_t maxiters);
+void qselect_(type_t *arr,
+              int64_t pos,
+              int64_t left,
+              int64_t right,
+              int64_t maxiters);
 
 // Regular quicksort routines:
 template <typename T>
@@ -683,7 +687,8 @@ void avx512_qsort(T *arr, int64_t arrsize)
     if (arrsize > 1) {
         /* std::is_floating_point_v<_Float16> == False, unless c++-23*/
         if constexpr (std::is_floating_point_v<T>) {
-            int64_t nan_count = replace_nan_with_inf<zmm_vector<T>>(arr, arrsize);
+            int64_t nan_count
+                    = replace_nan_with_inf<zmm_vector<T>>(arr, arrsize);
             qsort_<zmm_vector<T>, T>(
                     arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
             replace_inf_with_nan(arr, arrsize, nan_count);
@@ -713,15 +718,22 @@ void avx512_qselect(T *arr, int64_t k, int64_t arrsize, bool hasnan = false)
     }
 }
 
-void avx512_qselect_fp16(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan = false);
+void avx512_qselect_fp16(uint16_t *arr,
+                         int64_t k,
+                         int64_t arrsize,
+                         bool hasnan = false);
 
 template <typename T>
-inline void avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize, bool hasnan = false)
+inline void
+avx512_partial_qsort(T *arr, int64_t k, int64_t arrsize, bool hasnan = false)
 {
     avx512_qselect<T>(arr, k - 1, arrsize, hasnan);
     avx512_qsort<T>(arr, k - 1);
 }
-inline void avx512_partial_qsort_fp16(uint16_t *arr, int64_t k, int64_t arrsize, bool hasnan = false)
+inline void avx512_partial_qsort_fp16(uint16_t *arr,
+                                      int64_t k,
+                                      int64_t arrsize,
+                                      bool hasnan = false)
 {
     avx512_qselect_fp16(arr, k - 1, arrsize, hasnan);
     avx512_qsort_fp16(arr, k - 1);

--- a/src/avx512-common-qsort.h
+++ b/src/avx512-common-qsort.h
@@ -726,9 +726,4 @@ inline void avx512_partial_qsort_fp16(uint16_t *arr, int64_t k, int64_t arrsize,
     avx512_qselect_fp16(arr, k - 1, arrsize, hasnan);
     avx512_qsort_fp16(arr, k - 1);
 }
-
-// key-value sort routines
-template <typename T>
-void avx512_qsort_kv(T *keys, uint64_t *indexes, int64_t arrsize);
-
 #endif // AVX512_QSORT_COMMON

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -114,36 +114,6 @@ struct zmm_vector<_Float16> {
     }
 };
 
-X86_SIMD_SORT_INLINE int64_t replace_nan_with_inf(_Float16 *arr,
-                                                  int64_t arrsize)
-{
-    int64_t nan_count = 0;
-    __mmask32 loadmask = 0xFFFFFFFF;
-    __m512h in_zmm;
-    while (arrsize > 0) {
-        if (arrsize < 32) {
-            loadmask = (0x00000001 << arrsize) - 0x00000001;
-            in_zmm = _mm512_castsi512_ph(
-                    _mm512_maskz_loadu_epi16(loadmask, arr));
-        }
-        else {
-            in_zmm = _mm512_loadu_ph(arr);
-        }
-        __mmask32 nanmask = _mm512_cmp_ph_mask(in_zmm, in_zmm, _CMP_NEQ_UQ);
-        nan_count += _mm_popcnt_u32((int32_t)nanmask);
-        _mm512_mask_storeu_epi16(arr, nanmask, ZMM_MAX_HALF);
-        arr += 32;
-        arrsize -= 32;
-    }
-    return nan_count;
-}
-
-X86_SIMD_SORT_INLINE void
-replace_inf_with_nan(_Float16 *arr, int64_t arrsize, int64_t nan_count)
-{
-    memset(arr + arrsize - nan_count, 0xFF, nan_count * 2);
-}
-
 template <>
 bool is_a_nan<_Float16>(_Float16 elem)
 {
@@ -166,13 +136,8 @@ void avx512_qselect(_Float16 *arr, int64_t k, int64_t arrsize, bool hasnan)
 }
 
 template <>
-void avx512_qsort(_Float16 *arr, int64_t arrsize)
+void qsort_<zmm_vector<_Float16>>(_Float16* arr, int64_t left, int64_t right, int64_t maxiters)
 {
-    if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf(arr, arrsize);
-        qsort_16bit_<zmm_vector<_Float16>, _Float16>(
-                arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
-        replace_inf_with_nan(arr, arrsize, nan_count);
-    }
+    qsort_16bit_<zmm_vector<_Float16>>(arr, left, right, maxiters);
 }
 #endif // AVX512FP16_QSORT_16BIT

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -75,8 +75,7 @@ struct zmm_vector<_Float16> {
     }
     static zmm_t maskz_loadu(opmask_t mask, void const *mem)
     {
-        return _mm512_castsi512_ph(
-                _mm512_maskz_loadu_epi16(mask, mem));
+        return _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(mask, mem));
     }
     static zmm_t mask_loadu(zmm_t x, opmask_t mask, void const *mem)
     {
@@ -135,31 +134,36 @@ bool is_a_nan<_Float16>(_Float16 elem)
     return (temp.i_ & 0x7c00) == 0x7c00;
 }
 
-template<>
+template <>
 void replace_inf_with_nan(_Float16 *arr, int64_t arrsize, int64_t nan_count)
 {
     memset(arr + arrsize - nan_count, 0xFF, nan_count * 2);
 }
 
 template <>
-void qselect_<zmm_vector<_Float16>>(_Float16* arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
+void qselect_<zmm_vector<_Float16>>(
+        _Float16 *arr, int64_t k, int64_t left, int64_t right, int64_t maxiters)
 {
     qselect_16bit_<zmm_vector<_Float16>>(arr, k, left, right, maxiters);
 }
 
-
 template <>
-void qsort_<zmm_vector<_Float16>>(_Float16* arr, int64_t left, int64_t right, int64_t maxiters)
+void qsort_<zmm_vector<_Float16>>(_Float16 *arr,
+                                  int64_t left,
+                                  int64_t right,
+                                  int64_t maxiters)
 {
     qsort_16bit_<zmm_vector<_Float16>>(arr, left, right, maxiters);
 }
 
 /* Specialized template function for _Float16 qsort_*/
-template<>
+template <>
 void avx512_qsort(_Float16 *arr, int64_t arrsize)
 {
     if (arrsize > 1) {
-        int64_t nan_count = replace_nan_with_inf<zmm_vector<_Float16>, _Float16>(arr, arrsize);
+        int64_t nan_count
+                = replace_nan_with_inf<zmm_vector<_Float16>, _Float16>(arr,
+                                                                       arrsize);
         qsort_16bit_<zmm_vector<_Float16>, _Float16>(
                 arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
         replace_inf_with_nan(arr, arrsize, nan_count);

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -46,10 +46,18 @@ struct zmm_vector<_Float16> {
     {
         return _knot_mask32(x);
     }
-
     static opmask_t ge(zmm_t x, zmm_t y)
     {
         return _mm512_cmp_ph_mask(x, y, _CMP_GE_OQ);
+    }
+    static opmask_t get_partial_loadmask(int size)
+    {
+        return (0x00000001 << size) - 0x00000001;
+    }
+    template <int type>
+    static opmask_t fpclass(zmm_t x)
+    {
+        return _mm512_fpclass_ph_mask(x, type);
     }
     static zmm_t loadu(void const *mem)
     {
@@ -64,6 +72,11 @@ struct zmm_vector<_Float16> {
         __m512i temp = _mm512_castph_si512(x);
         // AVX512_VBMI2
         return _mm512_mask_compressstoreu_epi16(mem, mask, temp);
+    }
+    static zmm_t maskz_loadu(opmask_t mask, void const *mem)
+    {
+        return _mm512_castsi512_ph(
+                _mm512_maskz_loadu_epi16(mask, mem));
     }
     static zmm_t mask_loadu(zmm_t x, opmask_t mask, void const *mem)
     {
@@ -139,5 +152,22 @@ template <>
 void qsort_<zmm_vector<_Float16>>(_Float16* arr, int64_t left, int64_t right, int64_t maxiters)
 {
     qsort_16bit_<zmm_vector<_Float16>>(arr, left, right, maxiters);
+}
+
+template<>
+void replace_inf_with_nan(_Float16 *arr, int64_t arrsize, int64_t nan_count)
+{
+    memset(arr + arrsize - nan_count, 0xFF, nan_count * 2);
+}
+
+template<>
+void avx512_qsort(_Float16 *arr, int64_t arrsize)
+{
+    if (arrsize > 1) {
+        int64_t nan_count = replace_nan_with_inf<zmm_vector<_Float16>, _Float16>(arr, arrsize);
+        qsort_16bit_<zmm_vector<_Float16>, _Float16>(
+                arr, 0, arrsize - 1, 2 * (int64_t)log2(arrsize));
+        replace_inf_with_nan(arr, arrsize, nan_count);
+    }
 }
 #endif // AVX512FP16_QSORT_16BIT

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -54,7 +54,7 @@ TYPED_TEST_P(KeyValueSort, test_64bit_random_data)
             std::sort(sortedarr.begin(),
                       sortedarr.end(),
                       compare<TypeParam, uint64_t>);
-            avx512_qsort_kv<TypeParam>(keys.data(), values.data(), keys.size());
+            avx512_qsort_kv(keys.data(), values.data(), keys.size());
             for (size_t i = 0; i < keys.size(); i++) {
                 ASSERT_EQ(keys[i], sortedarr[i].key);
                 ASSERT_EQ(values[i], sortedarr[i].value);


### PR DESCRIPTION
Requires C++ 17