### PR TITLE
Explicitly initialize with zmm_vector<uint64_t> for arg methods on macOS

### DIFF
--- a/src/avx512-common-argsort.h
+++ b/src/avx512-common-argsort.h
@@ -12,9 +12,17 @@
 #include <stdio.h>
 #include <vector>
 
+/* Workaround for NumPy failed build on macOS x86_64: implicit instantiation of
+ * undefined template 'zmm_vector<unsigned long>'*/
+#ifdef __APPLE__
+using argtype = typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
+                                          ymm_vector<uint32_t>,
+                                          zmm_vector<uint64_t>>::type;
+#else
 using argtype = typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                           ymm_vector<arrsize_t>,
                                           zmm_vector<arrsize_t>>::type;
+#endif
 using argreg_t = typename argtype::reg_t;
 
 /*


### PR DESCRIPTION
For some reason, macOS clang-15++ does not like `zmm_vector<arrsize_t>` and it fails with: 
```

../numpy/_core/src/npysort/x86-simd-sort/src/avx512-common-argsort.h:18:27: error: implicit instantiation of undefined template 'zmm_vector<unsigned long>'
using argreg_t = typename argtype::reg_t;
                          ^
../numpy/_core/src/npysort/x86-simd-sort/src/avx512-common-qsort.h:111:8: note: template is declared here
struct zmm_vector;
```