### PR TITLE
AVX2 64-bit support

### DIFF
--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -1,5 +1,6 @@
 // AVX2 specific routines:
 #include "avx2-32bit-qsort.hpp"
+#include "avx2-64bit-qsort.hpp"
 #include "x86simdsort-internal.h"
 
 #define DEFINE_ALL_METHODS(type) \
@@ -24,5 +25,8 @@ namespace avx2 {
     DEFINE_ALL_METHODS(uint32_t)
     DEFINE_ALL_METHODS(int32_t)
     DEFINE_ALL_METHODS(float)
+    DEFINE_ALL_METHODS(uint64_t)
+    DEFINE_ALL_METHODS(int64_t)
+    DEFINE_ALL_METHODS(double)
 } // namespace avx2
 } // namespace xss

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -150,15 +150,15 @@ DISPATCH(argselect, _Float16, ISA_LIST("none"))
 DISPATCH_ALL(qsort,
              (ISA_LIST("avx512_icl")),
              (ISA_LIST("avx512_skx", "avx2")),
-             (ISA_LIST("avx512_skx")))
+             (ISA_LIST("avx512_skx", "avx2")))
 DISPATCH_ALL(qselect,
              (ISA_LIST("avx512_icl")),
              (ISA_LIST("avx512_skx", "avx2")),
-             (ISA_LIST("avx512_skx")))
+             (ISA_LIST("avx512_skx", "avx2")))
 DISPATCH_ALL(partial_qsort,
              (ISA_LIST("avx512_icl")),
              (ISA_LIST("avx512_skx", "avx2")),
-             (ISA_LIST("avx512_skx")))
+             (ISA_LIST("avx512_skx", "avx2")))
 DISPATCH_ALL(argsort,
              (ISA_LIST("none")),
              (ISA_LIST("avx512_skx")),

--- a/src/avx2-32bit-qsort.hpp
+++ b/src/avx2-32bit-qsort.hpp
@@ -135,7 +135,7 @@ struct avx2_vector<int32_t> {
     }
     static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
     {
-        return avx2_emu_mask_compressstoreu<type_t>(mem, mask, x);
+        return avx2_emu_mask_compressstoreu32<type_t>(mem, mask, x);
     }
     static reg_t maskz_loadu(opmask_t mask, void const *mem)
     {
@@ -289,7 +289,7 @@ struct avx2_vector<uint32_t> {
     }
     static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
     {
-        return avx2_emu_mask_compressstoreu<type_t>(mem, mask, x);
+        return avx2_emu_mask_compressstoreu32<type_t>(mem, mask, x);
     }
     static reg_t mask_loadu(reg_t x, opmask_t mask, void const *mem)
     {
@@ -459,7 +459,7 @@ struct avx2_vector<float> {
     }
     static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
     {
-        return avx2_emu_mask_compressstoreu<type_t>(mem, mask, x);
+        return avx2_emu_mask_compressstoreu32<type_t>(mem, mask, x);
     }
     static reg_t mask_loadu(reg_t x, opmask_t mask, void const *mem)
     {

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -1,0 +1,590 @@
+/*******************************************************************
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Authors: Raghuveer Devulapalli <raghuveer.devulapalli@intel.com>
+ *          Matthew Sterrett <matthew.sterrett@intel.com>
+ * ****************************************************************/
+
+#ifndef AVX2_QSORT_64BIT
+#define AVX2_QSORT_64BIT
+
+#include "xss-common-qsort.h"
+#include "avx2-emu-funcs.hpp"
+
+/*
+ * Constants used in sorting 8 elements in a ymm registers. Based on Bitonic
+ * sorting network (see
+ * https://en.wikipedia.org/wiki/Bitonic_sorter#/media/File:BitonicSort.svg)
+ */
+// ymm                  3, 2, 1, 0
+#define NETWORK_64BIT_R 0, 1, 2, 3
+#define NETWORK_64BIT_1 1, 0, 3, 2
+
+/*
+ * Assumes ymm is random and performs a full sorting network defined in
+ * https://en.wikipedia.org/wiki/Bitonic_sorter#/media/File:BitonicSort.svg
+ */
+template <typename vtype, typename reg_t = typename vtype::reg_t>
+X86_SIMD_SORT_INLINE reg_t sort_ymm_64bit(reg_t ymm)
+{
+    const typename vtype::opmask_t oxAA
+            = _mm256_set_epi64x(0xFFFFFFFFFFFFFFFF, 0, 0xFFFFFFFFFFFFFFFF, 0);
+    const typename vtype::opmask_t oxCC
+            = _mm256_set_epi64x(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0, 0);
+    ymm = cmp_merge<vtype>(
+            ymm,
+            vtype::template permutexvar<SHUFFLE_MASK(2, 3, 0, 1)>(ymm),
+            oxAA);
+    ymm = cmp_merge<vtype>(
+            ymm,
+            vtype::template permutexvar<SHUFFLE_MASK(0, 1, 2, 3)>(ymm),
+            oxCC);
+    ymm = cmp_merge<vtype>(
+            ymm,
+            vtype::template permutexvar<SHUFFLE_MASK(2, 3, 0, 1)>(ymm),
+            oxAA);
+    return ymm;
+}
+
+struct avx2_64bit_swizzle_ops;
+
+template <>
+struct avx2_vector<int64_t> {
+    using type_t = int64_t;
+    using reg_t = __m256i;
+    using ymmi_t = __m256i;
+    using opmask_t = __m256i;
+    static const uint8_t numlanes = 4;
+    static constexpr int network_sort_threshold = 64;
+    static constexpr int partition_unroll_factor = 4;
+    
+    using swizzle_ops = avx2_64bit_swizzle_ops;
+
+    static type_t type_max()
+    {
+        return X86_SIMD_SORT_MAX_INT64;
+    }
+    static type_t type_min()
+    {
+        return X86_SIMD_SORT_MIN_INT64;
+    }
+    static reg_t zmm_max()
+    {
+        return _mm256_set1_epi64x(type_max());
+    } // TODO: this should broadcast bits as is?
+    static opmask_t get_partial_loadmask(uint64_t num_to_read)
+    {
+        auto mask = ((0x1ull << num_to_read) - 0x1ull);
+        return convert_int_to_avx2_mask_64bit(mask);
+    }
+    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    {
+        return _mm256_set_epi64x(v1, v2, v3, v4);
+    }
+    static opmask_t kxor_opmask(opmask_t x, opmask_t y)
+    {
+        return _mm256_xor_si256(x, y);
+    }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        return ~x;
+    }
+    static opmask_t le(reg_t x, reg_t y)
+    {
+        return ~_mm256_cmpgt_epi64(x, y);
+    }
+    static opmask_t ge(reg_t x, reg_t y)
+    {
+        opmask_t equal = eq(x, y);
+        opmask_t greater = _mm256_cmpgt_epi64(x, y);
+        return _mm256_castpd_si256(_mm256_or_pd(_mm256_castsi256_pd(equal),
+                                                _mm256_castsi256_pd(greater)));
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm256_cmpeq_epi64(x, y);
+    }
+    template <int scale>
+    static reg_t
+    mask_i64gather(reg_t src, opmask_t mask, __m256i index, void const *base)
+    {
+        return _mm256_mask_i64gather_epi64(src, base, index, mask, scale);
+    }
+    template <int scale>
+    static reg_t i64gather(__m256i index, void const *base)
+    {
+        return _mm256_i64gather_epi64(
+                (long long int const *)base, index, scale);
+    }
+    static reg_t loadu(void const *mem)
+    {
+        return _mm256_loadu_si256((reg_t const *)mem);
+    }
+    static reg_t max(reg_t x, reg_t y)
+    {
+        return avx2_emu_max<type_t>(x, y);
+    }
+    static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
+    {
+        return avx2_emu_mask_compressstoreu64<type_t>(mem, mask, x);
+    }
+    static int32_t double_compressstore(void *left_addr,
+                                        void *right_addr,
+                                        opmask_t k,
+                                        reg_t reg)
+    {
+        return avx2_double_compressstore64<type_t>(
+                left_addr, right_addr, k, reg);
+    }
+    static reg_t maskz_loadu(opmask_t mask, void const *mem)
+    {
+        return _mm256_maskload_epi64((const long long int *)mem, mask);
+    }
+    static reg_t mask_loadu(reg_t x, opmask_t mask, void const *mem)
+    {
+        reg_t dst = _mm256_maskload_epi64((long long int *)mem, mask);
+        return mask_mov(x, mask, dst);
+    }
+    static reg_t mask_mov(reg_t x, opmask_t mask, reg_t y)
+    {
+        return _mm256_castpd_si256(_mm256_blendv_pd(_mm256_castsi256_pd(x),
+                                                    _mm256_castsi256_pd(y),
+                                                    _mm256_castsi256_pd(mask)));
+    }
+    static void mask_storeu(void *mem, opmask_t mask, reg_t x)
+    {
+        return _mm256_maskstore_epi64((long long int *)mem, mask, x);
+    }
+    static reg_t min(reg_t x, reg_t y)
+    {
+        return avx2_emu_min<type_t>(x, y);
+    }
+    template <int32_t idx>
+    static reg_t permutexvar(reg_t ymm)
+    {
+        return _mm256_permute4x64_epi64(ymm, idx);
+    }
+    template <int32_t idx>
+    static reg_t permutevar(reg_t ymm)
+    {
+        return _mm256_permute4x64_epi64(ymm, idx);
+    }
+    static reg_t reverse(reg_t ymm)
+    {
+        const int32_t rev_index = SHUFFLE_MASK(0, 1, 2, 3);
+        return permutexvar<rev_index>(ymm);
+    }
+    template <int index>
+    static type_t extract(reg_t v)
+    {
+        return _mm256_extract_epi64(v, index);
+    }
+    static type_t reducemax(reg_t v)
+    {
+        return avx2_emu_reduce_max64<type_t>(v);
+    }
+    static type_t reducemin(reg_t v)
+    {
+        return avx2_emu_reduce_min64<type_t>(v);
+    }
+    static reg_t set1(type_t v)
+    {
+        return _mm256_set1_epi64x(v);
+    }
+    template <uint8_t mask>
+    static reg_t shuffle(reg_t ymm)
+    {
+        return _mm256_castpd_si256(
+                _mm256_permute_pd(_mm256_castsi256_pd(ymm), mask));
+    }
+    static void storeu(void *mem, reg_t x)
+    {
+        _mm256_storeu_si256((__m256i *)mem, x);
+    }
+    static reg_t sort_vec(reg_t x)
+    {
+        return sort_ymm_64bit<avx2_vector<type_t>>(x);
+    }
+    static reg_t cast_from(__m256i v){
+        return v;
+    }
+    static __m256i cast_to(reg_t v){
+        return v;
+    }
+};
+template <>
+struct avx2_vector<uint64_t> {
+    using type_t = uint64_t;
+    using reg_t = __m256i;
+    using ymmi_t = __m256i;
+    using opmask_t = __m256i;
+    static const uint8_t numlanes = 4;
+    static constexpr int network_sort_threshold = 64;
+    static constexpr int partition_unroll_factor = 4;
+    
+    using swizzle_ops = avx2_64bit_swizzle_ops;
+
+    static type_t type_max()
+    {
+        return X86_SIMD_SORT_MAX_UINT64;
+    }
+    static type_t type_min()
+    {
+        return 0;
+    }
+    static reg_t zmm_max()
+    {
+        return _mm256_set1_epi64x(type_max());
+    }
+    static opmask_t get_partial_loadmask(uint64_t num_to_read)
+    {
+        auto mask = ((0x1ull << num_to_read) - 0x1ull);
+        return convert_int_to_avx2_mask_64bit(mask);
+    }
+    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    {
+        return _mm256_set_epi64x(v1, v2, v3, v4);
+    }
+    template <int scale>
+    static reg_t
+    mask_i64gather(reg_t src, opmask_t mask, __m256i index, void const *base)
+    {
+        return _mm256_mask_i64gather_epi64(src, base, index, mask, scale);
+    }
+    template <int scale>
+    static reg_t i64gather(__m256i index, void const *base)
+    {
+        return _mm256_i64gather_epi64(
+                (long long int const *)base, index, scale);
+    }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        return ~x;
+    }
+    static opmask_t ge(reg_t x, reg_t y)
+    {
+        opmask_t equal = eq(x, y);
+
+        const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
+        x = _mm256_add_epi64(x, offset);
+        y = _mm256_add_epi64(y, offset);
+
+        opmask_t greater = _mm256_cmpgt_epi64(x, y);
+        return _mm256_castpd_si256(_mm256_or_pd(_mm256_castsi256_pd(equal),
+                                                _mm256_castsi256_pd(greater)));
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm256_cmpeq_epi64(x, y);
+    }
+    static reg_t loadu(void const *mem)
+    {
+        return _mm256_loadu_si256((reg_t const *)mem);
+    }
+    static reg_t max(reg_t x, reg_t y)
+    {
+        return avx2_emu_max<type_t>(x, y);
+    }
+    static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
+    {
+        return avx2_emu_mask_compressstoreu64<type_t>(mem, mask, x);
+    }
+    static int32_t double_compressstore(void *left_addr,
+                                        void *right_addr,
+                                        opmask_t k,
+                                        reg_t reg)
+    {
+        return avx2_double_compressstore64<type_t>(
+                left_addr, right_addr, k, reg);
+    }
+    static reg_t mask_loadu(reg_t x, opmask_t mask, void const *mem)
+    {
+        reg_t dst = _mm256_maskload_epi64((const long long int *)mem, mask);
+        return mask_mov(x, mask, dst);
+    }
+    static reg_t mask_mov(reg_t x, opmask_t mask, reg_t y)
+    {
+        return _mm256_castpd_si256(_mm256_blendv_pd(_mm256_castsi256_pd(x),
+                                                    _mm256_castsi256_pd(y),
+                                                    _mm256_castsi256_pd(mask)));
+    }
+    static void mask_storeu(void *mem, opmask_t mask, reg_t x)
+    {
+        return _mm256_maskstore_epi64((long long int *)mem, mask, x);
+    }
+    static reg_t min(reg_t x, reg_t y)
+    {
+        return avx2_emu_min<type_t>(x, y);
+    }
+    template <int32_t idx>
+    static reg_t permutexvar(reg_t ymm)
+    {
+        return _mm256_permute4x64_epi64(ymm, idx);
+    }
+    template <int32_t idx>
+    static reg_t permutevar(reg_t ymm)
+    {
+        return _mm256_permute4x64_epi64(ymm, idx);
+    }
+    static reg_t reverse(reg_t ymm)
+    {
+        const int32_t rev_index = SHUFFLE_MASK(0, 1, 2, 3);
+        return permutexvar<rev_index>(ymm);
+    }
+    template <int index>
+    static type_t extract(reg_t v)
+    {
+        return _mm256_extract_epi64(v, index);
+    }
+    static type_t reducemax(reg_t v)
+    {
+        return avx2_emu_reduce_max64<type_t>(v);
+    }
+    static type_t reducemin(reg_t v)
+    {
+        return avx2_emu_reduce_min64<type_t>(v);
+    }
+    static reg_t set1(type_t v)
+    {
+        return _mm256_set1_epi64x(v);
+    }
+    template <uint8_t mask>
+    static reg_t shuffle(reg_t ymm)
+    {
+        return _mm256_castpd_si256(
+                _mm256_permute_pd(_mm256_castsi256_pd(ymm), mask));
+    }
+    static void storeu(void *mem, reg_t x)
+    {
+        _mm256_storeu_si256((__m256i *)mem, x);
+    }
+    static reg_t sort_vec(reg_t x)
+    {
+        return sort_ymm_64bit<avx2_vector<type_t>>(x);
+    }
+    static reg_t cast_from(__m256i v){
+        return v;
+    }
+    static __m256i cast_to(reg_t v){
+        return v;
+    }
+};
+template <>
+struct avx2_vector<double> {
+    using type_t = double;
+    using reg_t = __m256d;
+    using ymmi_t = __m256i;
+    using opmask_t = __m256i;
+    static const uint8_t numlanes = 4;
+    static constexpr int network_sort_threshold = 64;
+    static constexpr int partition_unroll_factor = 4;
+    
+    using swizzle_ops = avx2_64bit_swizzle_ops;
+
+    static type_t type_max()
+    {
+        return X86_SIMD_SORT_INFINITY;
+    }
+    static type_t type_min()
+    {
+        return -X86_SIMD_SORT_INFINITY;
+    }
+    static reg_t zmm_max()
+    {
+        return _mm256_set1_pd(type_max());
+    }
+    static opmask_t get_partial_loadmask(uint64_t num_to_read)
+    {
+        auto mask = ((0x1ull << num_to_read) - 0x1ull);
+        return convert_int_to_avx2_mask_64bit(mask);
+    }
+    static int32_t convert_mask_to_int(opmask_t mask)
+    {
+        return convert_avx2_mask_to_int_64bit(mask);
+    }
+    template <int type>
+    static opmask_t fpclass(reg_t x)
+    {
+        if constexpr (type == (0x01 | 0x80)) {
+            return _mm256_castpd_si256(_mm256_cmp_pd(x, x, _CMP_UNORD_Q));
+        }
+        else {
+            static_assert(type == (0x01 | 0x80), "should not reach here");
+        }
+    }
+    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    {
+        return _mm256_set_epi64x(v1, v2, v3, v4);
+    }
+
+    static reg_t maskz_loadu(opmask_t mask, void const *mem)
+    {
+        return _mm256_maskload_pd((const double *)mem, mask);
+    }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        return ~x;
+    }
+    static opmask_t ge(reg_t x, reg_t y)
+    {
+        return _mm256_castpd_si256(_mm256_cmp_pd(x, y, _CMP_GE_OQ));
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm256_castpd_si256(_mm256_cmp_pd(x, y, _CMP_EQ_OQ));
+    }
+    template <int scale>
+    static reg_t
+    mask_i64gather(reg_t src, opmask_t mask, __m256i index, void const *base)
+    {
+        return _mm256_mask_i64gather_pd(
+                src, base, index, _mm256_castsi256_pd(mask), scale);
+        ;
+    }
+    template <int scale>
+    static reg_t i64gather(__m256i index, void const *base)
+    {
+        return _mm256_i64gather_pd((double *)base, index, scale);
+    }
+    static reg_t loadu(void const *mem)
+    {
+        return _mm256_loadu_pd((double const *)mem);
+    }
+    static reg_t max(reg_t x, reg_t y)
+    {
+        return _mm256_max_pd(x, y);
+    }
+    static void mask_compressstoreu(void *mem, opmask_t mask, reg_t x)
+    {
+        return avx2_emu_mask_compressstoreu64<type_t>(mem, mask, x);
+    }
+    static int32_t double_compressstore(void *left_addr,
+                                        void *right_addr,
+                                        opmask_t k,
+                                        reg_t reg)
+    {
+        return avx2_double_compressstore64<type_t>(
+                left_addr, right_addr, k, reg);
+    }
+    static reg_t mask_loadu(reg_t x, opmask_t mask, void const *mem)
+    {
+        reg_t dst = _mm256_maskload_pd((type_t *)mem, mask);
+        return mask_mov(x, mask, dst);
+    }
+    static reg_t mask_mov(reg_t x, opmask_t mask, reg_t y)
+    {
+        return _mm256_blendv_pd(x, y, _mm256_castsi256_pd(mask));
+    }
+    static void mask_storeu(void *mem, opmask_t mask, reg_t x)
+    {
+        return _mm256_maskstore_pd((type_t *)mem, mask, x);
+    }
+    static reg_t min(reg_t x, reg_t y)
+    {
+        return _mm256_min_pd(x, y);
+    }
+    template <int32_t idx>
+    static reg_t permutexvar(reg_t ymm)
+    {
+        return _mm256_permute4x64_pd(ymm, idx);
+    }
+    template <int32_t idx>
+    static reg_t permutevar(reg_t ymm)
+    {
+        return _mm256_permute4x64_pd(ymm, idx);
+    }
+    static reg_t reverse(reg_t ymm)
+    {
+        const int32_t rev_index = SHUFFLE_MASK(0, 1, 2, 3);
+        return permutexvar<rev_index>(ymm);
+    }
+    template <int index>
+    static type_t extract(reg_t v)
+    {
+        int64_t x = _mm256_extract_epi64(_mm256_castpd_si256(v), index);
+        double y;
+        std::memcpy(&y, &x, sizeof(y));
+        return y;
+    }
+    static type_t reducemax(reg_t v)
+    {
+        return avx2_emu_reduce_max64<type_t>(v);
+    }
+    static type_t reducemin(reg_t v)
+    {
+        return avx2_emu_reduce_min64<type_t>(v);
+    }
+    static reg_t set1(type_t v)
+    {
+        return _mm256_set1_pd(v);
+    }
+    template <uint8_t mask>
+    static reg_t shuffle(reg_t ymm)
+    {
+        return _mm256_permute_pd(ymm, mask);
+    }
+    static void storeu(void *mem, reg_t x)
+    {
+        _mm256_storeu_pd((double *)mem, x);
+    }
+    static reg_t sort_vec(reg_t x)
+    {
+        return sort_ymm_64bit<avx2_vector<type_t>>(x);
+    }
+    static reg_t cast_from(__m256i v){
+        return _mm256_castsi256_pd(v);
+    }
+    static __m256i cast_to(reg_t v){
+        return _mm256_castpd_si256(v);
+    }
+};
+
+struct avx2_64bit_swizzle_ops{
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t swap_n(typename vtype::reg_t reg){
+        __m256i v = vtype::cast_to(reg);
+
+        if constexpr (scale == 2){
+            v = _mm256_permute4x64_epi64(v, 0b10110001);
+        }else if constexpr (scale == 4){
+            v = _mm256_permute4x64_epi64(v, 0b01001110);
+        }else{
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(v);
+    }
+
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t reverse_n(typename vtype::reg_t reg){
+        __m256i v = vtype::cast_to(reg);
+
+        if constexpr (scale == 2){
+            return swap_n<vtype, 2>(reg);
+        }else if constexpr (scale == 4){
+            return vtype::reverse(reg);
+        }else{
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(v);
+    }
+
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t merge_n(typename vtype::reg_t reg, typename vtype::reg_t other){
+        __m256d v1 = _mm256_castsi256_pd(vtype::cast_to(reg));
+        __m256d v2 = _mm256_castsi256_pd(vtype::cast_to(other));
+
+        if constexpr (scale == 2){
+            v1 = _mm256_blend_pd(v1, v2, 0b0101);
+        }else if constexpr (scale == 4){
+            v1 = _mm256_blend_pd(v1, v2, 0b0011);
+        }else{
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(_mm256_castpd_si256(v1));
+    }
+};
+
+#endif // AVX2_QSORT_32BIT

--- a/src/avx2-emu-funcs.hpp
+++ b/src/avx2-emu-funcs.hpp
@@ -178,8 +178,8 @@ T avx2_emu_reduce_min64(typename avx2_vector<T>::reg_t x)
 
 template <typename T>
 void avx2_emu_mask_compressstoreu32(void *base_addr,
-                                  typename avx2_vector<T>::opmask_t k,
-                                  typename avx2_vector<T>::reg_t reg)
+                                    typename avx2_vector<T>::opmask_t k,
+                                    typename avx2_vector<T>::reg_t reg)
 {
     using vtype = avx2_vector<T>;
 
@@ -198,8 +198,8 @@ void avx2_emu_mask_compressstoreu32(void *base_addr,
 
 template <typename T>
 void avx2_emu_mask_compressstoreu64(void *base_addr,
-                                  typename avx2_vector<T>::opmask_t k,
-                                  typename avx2_vector<T>::reg_t reg)
+                                    typename avx2_vector<T>::opmask_t k,
+                                    typename avx2_vector<T>::reg_t reg)
 {
     using vtype = avx2_vector<T>;
 
@@ -211,7 +211,8 @@ void avx2_emu_mask_compressstoreu64(void *base_addr,
     const __m256i &left = _mm256_loadu_si256(
             (const __m256i *)avx2_compressstore_lut64_left[shortMask].data());
 
-    typename vtype::reg_t temp = vtype::cast_from(_mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
+    typename vtype::reg_t temp = vtype::cast_from(
+            _mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
 
     vtype::mask_storeu(leftStore, left, temp);
 }
@@ -258,7 +259,8 @@ int32_t avx2_double_compressstore64(void *left_addr,
     const __m256i &left = _mm256_loadu_si256(
             (const __m256i *)avx2_compressstore_lut64_left[shortMask].data());
 
-    typename vtype::reg_t temp = vtype::cast_from(_mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
+    typename vtype::reg_t temp = vtype::cast_from(
+            _mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
 
     vtype::mask_storeu(leftStore, left, temp);
     vtype::mask_storeu(rightStore, ~left, temp);

--- a/src/avx2-emu-funcs.hpp
+++ b/src/avx2-emu-funcs.hpp
@@ -20,6 +20,21 @@ constexpr auto avx2_mask_helper_lut32 = [] {
     return lut;
 }();
 
+constexpr auto avx2_mask_helper_lut64 = [] {
+    std::array<std::array<int64_t, 4>, 16> lut {};
+    for (int64_t i = 0; i <= 0xF; i++) {
+        std::array<int64_t, 4> entry {};
+        for (int j = 0; j < 4; j++) {
+            if (((i >> j) & 1) == 1)
+                entry[j] = 0xFFFFFFFFFFFFFFFF;
+            else
+                entry[j] = 0;
+        }
+        lut[i] = entry;
+    }
+    return lut;
+}();
+
 constexpr auto avx2_compressstore_lut32_gen = [] {
     std::array<std::array<std::array<int32_t, 8>, 256>, 2> lutPair {};
     auto &permLut = lutPair[0];
@@ -50,6 +65,38 @@ constexpr auto avx2_compressstore_lut32_gen = [] {
 constexpr auto avx2_compressstore_lut32_perm = avx2_compressstore_lut32_gen[0];
 constexpr auto avx2_compressstore_lut32_left = avx2_compressstore_lut32_gen[1];
 
+constexpr auto avx2_compressstore_lut64_gen = [] {
+    std::array<std::array<int32_t, 8>, 16> permLut {};
+    std::array<std::array<int64_t, 4>, 16> leftLut {};
+    for (int64_t i = 0; i <= 0xF; i++) {
+        std::array<int32_t, 8> indices {};
+        std::array<int64_t, 4> leftEntry = {0, 0, 0, 0};
+        int right = 7;
+        int left = 0;
+        for (int j = 0; j < 4; j++) {
+            bool ge = (i >> j) & 1;
+            if (ge) {
+                indices[right] = 2 * j + 1;
+                indices[right - 1] = 2 * j;
+                right -= 2;
+            }
+            else {
+                indices[left + 1] = 2 * j + 1;
+                indices[left] = 2 * j;
+                leftEntry[left / 2] = 0xFFFFFFFFFFFFFFFF;
+                left += 2;
+            }
+        }
+        permLut[i] = indices;
+        leftLut[i] = leftEntry;
+    }
+    return std::make_pair(permLut, leftLut);
+}();
+constexpr auto avx2_compressstore_lut64_perm
+        = avx2_compressstore_lut64_gen.first;
+constexpr auto avx2_compressstore_lut64_left
+        = avx2_compressstore_lut64_gen.second;
+
 X86_SIMD_SORT_INLINE
 __m256i convert_int_to_avx2_mask(int32_t m)
 {
@@ -61,6 +108,19 @@ X86_SIMD_SORT_INLINE
 int32_t convert_avx2_mask_to_int(__m256i m)
 {
     return _mm256_movemask_ps(_mm256_castsi256_ps(m));
+}
+
+X86_SIMD_SORT_INLINE
+__m256i convert_int_to_avx2_mask_64bit(int32_t m)
+{
+    return _mm256_loadu_si256(
+            (const __m256i *)avx2_mask_helper_lut64[m].data());
+}
+
+X86_SIMD_SORT_INLINE
+int32_t convert_avx2_mask_to_int_64bit(__m256i m)
+{
+    return _mm256_movemask_pd(_mm256_castsi256_pd(m));
 }
 
 // Emulators for intrinsics missing from AVX2 compared to AVX512
@@ -95,7 +155,29 @@ T avx2_emu_reduce_min32(typename avx2_vector<T>::reg_t x)
 }
 
 template <typename T>
-void avx2_emu_mask_compressstoreu(void *base_addr,
+T avx2_emu_reduce_max64(typename avx2_vector<T>::reg_t x)
+{
+    using vtype = avx2_vector<T>;
+    typename vtype::reg_t inter1 = vtype::max(
+            x, vtype::template permutexvar<SHUFFLE_MASK(2, 3, 0, 1)>(x));
+    T can1 = vtype::template extract<0>(inter1);
+    T can2 = vtype::template extract<2>(inter1);
+    return std::max<T>(can1, can2);
+}
+
+template <typename T>
+T avx2_emu_reduce_min64(typename avx2_vector<T>::reg_t x)
+{
+    using vtype = avx2_vector<T>;
+    typename vtype::reg_t inter1 = vtype::min(
+            x, vtype::template permutexvar<SHUFFLE_MASK(2, 3, 0, 1)>(x));
+    T can1 = vtype::template extract<0>(inter1);
+    T can2 = vtype::template extract<2>(inter1);
+    return std::min<T>(can1, can2);
+}
+
+template <typename T>
+void avx2_emu_mask_compressstoreu32(void *base_addr,
                                   typename avx2_vector<T>::opmask_t k,
                                   typename avx2_vector<T>::reg_t reg)
 {
@@ -110,6 +192,26 @@ void avx2_emu_mask_compressstoreu(void *base_addr,
             (const __m256i *)avx2_compressstore_lut32_left[shortMask].data());
 
     typename vtype::reg_t temp = vtype::permutevar(reg, perm);
+
+    vtype::mask_storeu(leftStore, left, temp);
+}
+
+template <typename T>
+void avx2_emu_mask_compressstoreu64(void *base_addr,
+                                  typename avx2_vector<T>::opmask_t k,
+                                  typename avx2_vector<T>::reg_t reg)
+{
+    using vtype = avx2_vector<T>;
+
+    T *leftStore = (T *)base_addr;
+
+    int32_t shortMask = convert_avx2_mask_to_int_64bit(k);
+    const __m256i &perm = _mm256_loadu_si256(
+            (const __m256i *)avx2_compressstore_lut64_perm[shortMask].data());
+    const __m256i &left = _mm256_loadu_si256(
+            (const __m256i *)avx2_compressstore_lut64_left[shortMask].data());
+
+    typename vtype::reg_t temp = vtype::cast_from(_mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
 
     vtype::mask_storeu(leftStore, left, temp);
 }
@@ -132,6 +234,31 @@ int avx2_double_compressstore32(void *left_addr,
             (const __m256i *)avx2_compressstore_lut32_left[shortMask].data());
 
     typename vtype::reg_t temp = vtype::permutevar(reg, perm);
+
+    vtype::mask_storeu(leftStore, left, temp);
+    vtype::mask_storeu(rightStore, ~left, temp);
+
+    return _mm_popcnt_u32(shortMask);
+}
+
+template <typename T>
+int32_t avx2_double_compressstore64(void *left_addr,
+                                    void *right_addr,
+                                    typename avx2_vector<T>::opmask_t k,
+                                    typename avx2_vector<T>::reg_t reg)
+{
+    using vtype = avx2_vector<T>;
+
+    T *leftStore = (T *)left_addr;
+    T *rightStore = (T *)right_addr;
+
+    int32_t shortMask = convert_avx2_mask_to_int_64bit(k);
+    const __m256i &perm = _mm256_loadu_si256(
+            (const __m256i *)avx2_compressstore_lut64_perm[shortMask].data());
+    const __m256i &left = _mm256_loadu_si256(
+            (const __m256i *)avx2_compressstore_lut64_left[shortMask].data());
+
+    typename vtype::reg_t temp = vtype::cast_from(_mm256_permutevar8x32_epi32(vtype::cast_to(reg), perm));
 
     vtype::mask_storeu(leftStore, left, temp);
     vtype::mask_storeu(rightStore, ~left, temp);


### PR DESCRIPTION
This adds support for 64 bit signed and unsigned integers as well as double.
 ```
Benchmark                                                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------
[scalarsort.*random vs. simdsort.*random]_128/uint64_t                 +0.2167         +0.2168          1473          1792          1474          1794
[scalarsort.*random vs. simdsort.*random]_256/uint64_t                 +0.4015         +0.4024          2238          3137          2239          3140
[scalarsort.*random vs. simdsort.*random]_512/uint64_t                 +0.4101         +0.4104          4017          5665          4018          5667
[scalarsort.*random vs. simdsort.*random]_1k/uint64_t                  -0.2849         -0.2847         16574         11852         16576         11857
[scalarsort.*random vs. simdsort.*random]_5k/uint64_t                  -0.7358         -0.7358        234470         61939        234491         61948
[scalarsort.*random vs. simdsort.*random]_100k/uint64_t                -0.7067         -0.7067       6414865       1881636       6414637       1881570
[scalarsort.*random vs. simdsort.*random]_1m/uint64_t                  -0.7023         -0.7023      75780531      22560374      75776030      22558344
[scalarsort.*random vs. simdsort.*random]_10m/uint64_t                 -0.7024         -0.7024     901927451     268434143     901823797     268403663
[scalarsort.*random vs. simdsort.*random]_128/int64_t                  +0.1570         +0.1574          1438          1664          1439          1665
[scalarsort.*random vs. simdsort.*random]_256/int64_t                  +0.2673         +0.2679          2197          2784          2198          2787
[scalarsort.*random vs. simdsort.*random]_512/int64_t                  +0.2628         +0.2638          3930          4963          3930          4967
[scalarsort.*random vs. simdsort.*random]_1k/int64_t                   -0.2445         -0.2443         13535         10225         13536         10229
[scalarsort.*random vs. simdsort.*random]_5k/int64_t                   -0.7711         -0.7711        231237         52920        231261         52928
[scalarsort.*random vs. simdsort.*random]_100k/int64_t                 -0.7410         -0.7410       6311722       1634694       6311216       1634541
[scalarsort.*random vs. simdsort.*random]_1m/int64_t                   -0.7326         -0.7327      74504489      19919243      74499187      19915838
[scalarsort.*random vs. simdsort.*random]_10m/int64_t                  -0.7342         -0.7342     889359086     236422366     889271533     236395618
[scalarsort.*random vs. simdsort.*random]_128/double                   -0.1461         -0.1457          1515          1294          1517          1296
[scalarsort.*random vs. simdsort.*random]_256/double                   -0.1358         -0.1350          2477          2140          2478          2143
[scalarsort.*random vs. simdsort.*random]_512/double                   -0.2540         -0.2533          4435          3309          4436          3313
[scalarsort.*random vs. simdsort.*random]_1k/double                    -0.5494         -0.5497         15236          6865         15251          6867
[scalarsort.*random vs. simdsort.*random]_5k/double                    -0.8510         -0.8509        248527         37041        248550         37047
[scalarsort.*random vs. simdsort.*random]_100k/double                  -0.8067         -0.8067       6705854       1296268       6705526       1296134
[scalarsort.*random vs. simdsort.*random]_1m/double                    -0.7992         -0.7992      81622570      16392520      81611182      16388987
[scalarsort.*random vs. simdsort.*random]_10m/double                   -0.7868         -0.7869     957027419     203991024     956927995     203957561
```