### PR TITLE
Improve emulation of AVX2 min/max 64-bit 

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -11,7 +11,7 @@ if [ ! -d .bench/google-benchmark ]; then
 fi
 compare=$(realpath .bench/google-benchmark/tools/compare.py)
 
-meson setup --warnlevel 0 --buildtype release builddir-${branch}
+meson setup -Dbuild_benchmarks=true --warnlevel 0 --buildtype release builddir-${branch}
 cd builddir-${branch}
 ninja
 $compare filters ./benchexe $1 $2

--- a/scripts/branch-compare.sh
+++ b/scripts/branch-compare.sh
@@ -27,7 +27,7 @@ build_branch() {
         fi
     fi
     cd $dir_name
-    meson setup --warnlevel 0 --buildtype release builddir
+    meson setup -Dbuild_benchmarks=true --warnlevel 0 --buildtype release builddir
     cd builddir
     ninja
     cd ../../

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -264,16 +264,16 @@ struct avx2_vector<uint64_t> {
     static opmask_t gt(reg_t x, reg_t y)
     {
         const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
-        x = _mm256_add_epi64(x, offset);
-        y = _mm256_add_epi64(y, offset);
+        x = _mm256_xor_si256(x, offset);
+        y = _mm256_xor_si256(y, offset);
         return _mm256_cmpgt_epi64(x, y);
     }
     static opmask_t ge(reg_t x, reg_t y)
     {
         opmask_t equal = eq(x, y);
         const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
-        x = _mm256_add_epi64(x, offset);
-        y = _mm256_add_epi64(y, offset);
+        x = _mm256_xor_si256(x, offset);
+        y = _mm256_xor_si256(y, offset);
 
         opmask_t greater = _mm256_cmpgt_epi64(x, y);
         return _mm256_castpd_si256(_mm256_or_pd(_mm256_castsi256_pd(equal),

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -274,10 +274,8 @@ struct avx2_vector<uint64_t> {
         const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
         x = _mm256_xor_si256(x, offset);
         y = _mm256_xor_si256(y, offset);
-
         opmask_t greater = _mm256_cmpgt_epi64(x, y);
-        return _mm256_castpd_si256(_mm256_or_pd(_mm256_castsi256_pd(equal),
-                                                _mm256_castsi256_pd(greater)));
+        return _mm256_or_si256(equal, greater);
     }
     static opmask_t eq(reg_t x, reg_t y)
     {

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -60,7 +60,7 @@ struct avx2_vector<int64_t> {
 #else
     static constexpr int network_sort_threshold = 64;
 #endif
-    static constexpr int partition_unroll_factor = 4;
+    static constexpr int partition_unroll_factor = 8;
 
     using swizzle_ops = avx2_64bit_swizzle_ops;
 
@@ -224,7 +224,7 @@ struct avx2_vector<uint64_t> {
 #else
     static constexpr int network_sort_threshold = 64;
 #endif
-    static constexpr int partition_unroll_factor = 4;
+    static constexpr int partition_unroll_factor = 8;
 
     using swizzle_ops = avx2_64bit_swizzle_ops;
 
@@ -387,7 +387,7 @@ struct avx2_vector<double> {
 #else
     static constexpr int network_sort_threshold = 64;
 #endif
-    static constexpr int partition_unroll_factor = 4;
+    static constexpr int partition_unroll_factor = 8;
 
     using swizzle_ops = avx2_64bit_swizzle_ops;
 

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -89,12 +89,15 @@ struct avx2_vector<int64_t> {
     {
         return _mm256_xor_si256(x, y);
     }
+    static opmask_t gt(reg_t x, reg_t y)
+    {
+        return _mm256_cmpgt_epi64(x, y);
+    }
     static opmask_t ge(reg_t x, reg_t y)
     {
         opmask_t equal = eq(x, y);
         opmask_t greater = _mm256_cmpgt_epi64(x, y);
-        return _mm256_castpd_si256(_mm256_or_pd(_mm256_castsi256_pd(equal),
-                                                _mm256_castsi256_pd(greater)));
+        return _mm256_or_si256(equal, greater);
     }
     static opmask_t eq(reg_t x, reg_t y)
     {
@@ -258,10 +261,16 @@ struct avx2_vector<uint64_t> {
         return _mm256_i64gather_epi64(
                 (long long int const *)base, index, scale);
     }
+    static opmask_t gt(reg_t x, reg_t y)
+    {
+        const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
+        x = _mm256_add_epi64(x, offset);
+        y = _mm256_add_epi64(y, offset);
+        return _mm256_cmpgt_epi64(x, y);
+    }
     static opmask_t ge(reg_t x, reg_t y)
     {
         opmask_t equal = eq(x, y);
-
         const __m256i offset = _mm256_set1_epi64x(0x8000000000000000);
         x = _mm256_add_epi64(x, offset);
         y = _mm256_add_epi64(y, offset);

--- a/src/avx2-emu-funcs.hpp
+++ b/src/avx2-emu-funcs.hpp
@@ -273,7 +273,7 @@ typename avx2_vector<T>::reg_t avx2_emu_max(typename avx2_vector<T>::reg_t x,
                                             typename avx2_vector<T>::reg_t y)
 {
     using vtype = avx2_vector<T>;
-    typename vtype::opmask_t nlt = vtype::ge(x, y);
+    typename vtype::opmask_t nlt = vtype::gt(x, y);
     return _mm256_castpd_si256(_mm256_blendv_pd(_mm256_castsi256_pd(y),
                                                 _mm256_castsi256_pd(x),
                                                 _mm256_castsi256_pd(nlt)));
@@ -284,7 +284,7 @@ typename avx2_vector<T>::reg_t avx2_emu_min(typename avx2_vector<T>::reg_t x,
                                             typename avx2_vector<T>::reg_t y)
 {
     using vtype = avx2_vector<T>;
-    typename vtype::opmask_t nlt = vtype::ge(x, y);
+    typename vtype::opmask_t nlt = vtype::gt(x, y);
     return _mm256_castpd_si256(_mm256_blendv_pd(_mm256_castsi256_pd(x),
                                                 _mm256_castsi256_pd(y),
                                                 _mm256_castsi256_pd(nlt)));


### PR DESCRIPTION
Improves benchmarks by about 1.25x.

```
Benchmark                                                                   Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1597         -0.1595         61073         51322         61080         51340
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1482         -0.1482       1926998       1641449       1926924       1641282
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1385         -0.1386      23119151      19916947      23117303      19914147
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1305         -0.1306     274425664     238612093     274388498     238561940
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1942         -0.1943         54594         43993         54612         44002
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1528         -0.1529       1699531       1439793       1699414       1439623
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1404         -0.1404      20536591      17654205      20534818      17652359
[simdsort/random_.*int64_t vs. simdsort/random_.*int64_t]                -0.1287         -0.1287     244993708     213467588     244956884     213438188
```
