### PR TITLE
Add API to sort array of custom objects

### DIFF
--- a/benchmarks/bench-all.cpp
+++ b/benchmarks/bench-all.cpp
@@ -4,3 +4,4 @@
 #include "bench-qselect.hpp"
 #include "bench-qsort.hpp"
 #include "bench-keyvalue.hpp"
+#include "bench-objsort.hpp"

--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -1,8 +1,16 @@
 #include <cmath>
+
+static constexpr char x[] = "x";
+static constexpr char euclidean[] = "euclidean";
+static constexpr char taxicab[] = "taxicab";
+static constexpr char chebyshev[] = "chebyshev";
+
+template <const char* val>
 struct Point3D {
     double x;
     double y;
     double z;
+    static constexpr std::string_view name {val};
     Point3D()
     {
         x = (double)rand() / RAND_MAX;
@@ -11,21 +19,18 @@ struct Point3D {
     }
     double distance()
     {
-        return std::sqrt(x * x + y * y + z * z);
-    }
-};
-
-struct Point2D {
-    double x;
-    double y;
-    Point2D()
-    {
-        x = (double)rand() / RAND_MAX;
-        y = (double)rand() / RAND_MAX;
-    }
-    double distance()
-    {
-        return std::sqrt(x * x + y * y);
+        if constexpr (name == "x") {
+            return x;
+        }
+        else if constexpr (name == "euclidean") {
+            return std::sqrt(x * x + y * y + z * z);
+        }
+        else if constexpr (name == "taxicab") {
+            return abs(x) + abs(y) + abs(z);
+        }
+        else if constexpr (name == "chebyshev") {
+            return std::max(std::max(x, y), z);
+        }
     }
 };
 
@@ -93,7 +98,11 @@ static void simdobjsort(benchmark::State &state)
             ->Arg(10e5) \
             ->Arg(10e6);
 
-BENCHMARK_OBJSORT(simdobjsort, Point2D)
-BENCHMARK_OBJSORT(scalarobjsort, Point2D)
-BENCHMARK_OBJSORT(simdobjsort, Point3D)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D)
+BENCHMARK_OBJSORT(simdobjsort, Point3D<x>)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D<x>)
+BENCHMARK_OBJSORT(simdobjsort, Point3D<taxicab>)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D<taxicab>)
+BENCHMARK_OBJSORT(simdobjsort, Point3D<euclidean>)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D<euclidean>)
+BENCHMARK_OBJSORT(simdobjsort, Point3D<chebyshev>)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D<chebyshev>)

--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -1,0 +1,98 @@
+#include <cmath>
+struct Point3D {
+    double x;
+    double y;
+    double z;
+    Point3D()
+    {
+        x = (double)rand() / RAND_MAX;
+        y = (double)rand() / RAND_MAX;
+        z = (double)rand() / RAND_MAX;
+    }
+    double distance()
+    {
+        return sqrt(x * x + y * y + z * z);
+    }
+};
+
+struct Point2D {
+    double x;
+    double y;
+    Point2D()
+    {
+        x = (double)rand() / RAND_MAX;
+        y = (double)rand() / RAND_MAX;
+    }
+    double distance()
+    {
+        return sqrt(x * x + y * y);
+    }
+};
+
+template <typename T>
+std::vector<T> init_data(const int size)
+{
+    srand(42);
+    std::vector<T> arr;
+    for (auto ii = 0; ii < size; ++ii) {
+        T temp;
+        arr.push_back(temp);
+    }
+    return arr;
+}
+
+template <typename T>
+struct less_than_key {
+    inline bool operator()(T &p1, T &p2)
+    {
+        return (p1.distance() < p2.distance());
+    }
+};
+
+template <typename T>
+static void scalarobjsort(benchmark::State &state)
+{
+    // set up array
+    std::vector<T> arr = init_data<T>(state.range(0));
+    std::vector<T> arr_bkp = arr;
+    // benchmark
+    for (auto _ : state) {
+        std::sort(arr.begin(), arr.end(), less_than_key<T>());
+        state.PauseTiming();
+        arr = arr_bkp;
+        state.ResumeTiming();
+    }
+}
+
+template <typename T>
+static void simdobjsort(benchmark::State &state)
+{
+    // set up array
+    std::vector<T> arr = init_data<T>(state.range(0));
+    std::vector<T> arr_bkp = arr;
+    // benchmark
+    for (auto _ : state) {
+        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> double {
+            return p.distance();
+        });
+        state.PauseTiming();
+        if (!std::is_sorted(arr.begin(), arr.end(), less_than_key<T>())) {
+            std::cout << "sorting failed \n";
+        }
+        arr = arr_bkp;
+        state.ResumeTiming();
+    }
+}
+
+#define BENCHMARK_OBJSORT(func, T) \
+    BENCHMARK_TEMPLATE(func, T) \
+            ->Arg(10e2) \
+            ->Arg(10e3) \
+            ->Arg(10e4) \
+            ->Arg(10e5) \
+            ->Arg(10e6);
+
+BENCHMARK_OBJSORT(simdobjsort, Point2D)
+BENCHMARK_OBJSORT(scalarobjsort, Point2D)
+BENCHMARK_OBJSORT(simdobjsort, Point3D)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D)

--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -1,31 +1,31 @@
 #include <cmath>
 struct Point3D {
-    double x;
-    double y;
-    double z;
+    float x;
+    float y;
+    float z;
     Point3D()
     {
-        x = (double)rand() / RAND_MAX;
-        y = (double)rand() / RAND_MAX;
-        z = (double)rand() / RAND_MAX;
+        x = (float)rand() / RAND_MAX;
+        y = (float)rand() / RAND_MAX;
+        z = (float)rand() / RAND_MAX;
     }
-    double distance()
+    float distance()
     {
-        return sqrt(x * x + y * y + z * z);
+        return x; //sqrt(x * x + y * y + z * z);
     }
 };
 
 struct Point2D {
-    double x;
-    double y;
+    float x;
+    float y;
     Point2D()
     {
-        x = (double)rand() / RAND_MAX;
-        y = (double)rand() / RAND_MAX;
+        x = (float)rand() / RAND_MAX;
+        y = (float)rand() / RAND_MAX;
     }
-    double distance()
+    float distance()
     {
-        return sqrt(x * x + y * y);
+        return x; //sqrt(x * x + y * y);
     }
 };
 
@@ -54,6 +54,8 @@ static void scalarobjsort(benchmark::State &state)
 {
     // set up array
     std::vector<T> arr = init_data<T>(state.range(0));
+    //std::sort(arr.begin(), arr.end(), less_than_key<T>());
+    //std::reverse(arr.begin(), arr.end());
     std::vector<T> arr_bkp = arr;
     // benchmark
     for (auto _ : state) {
@@ -69,10 +71,12 @@ static void simdobjsort(benchmark::State &state)
 {
     // set up array
     std::vector<T> arr = init_data<T>(state.range(0));
+    //std::sort(arr.begin(), arr.end(), less_than_key<T>());
+    //std::reverse(arr.begin(), arr.end());
     std::vector<T> arr_bkp = arr;
     // benchmark
     for (auto _ : state) {
-        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> double {
+        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> float {
             return p.distance();
         });
         state.PauseTiming();

--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -1,31 +1,31 @@
 #include <cmath>
 struct Point3D {
-    float x;
-    float y;
-    float z;
+    double x;
+    double y;
+    double z;
     Point3D()
     {
-        x = (float)rand() / RAND_MAX;
-        y = (float)rand() / RAND_MAX;
-        z = (float)rand() / RAND_MAX;
+        x = (double)rand() / RAND_MAX;
+        y = (double)rand() / RAND_MAX;
+        z = (double)rand() / RAND_MAX;
     }
-    float distance()
+    double distance()
     {
-        return x; //sqrt(x * x + y * y + z * z);
+        return std::sqrt(x * x + y * y + z * z);
     }
 };
 
 struct Point2D {
-    float x;
-    float y;
+    double x;
+    double y;
     Point2D()
     {
-        x = (float)rand() / RAND_MAX;
-        y = (float)rand() / RAND_MAX;
+        x = (double)rand() / RAND_MAX;
+        y = (double)rand() / RAND_MAX;
     }
-    float distance()
+    double distance()
     {
-        return x; //sqrt(x * x + y * y);
+        return std::sqrt(x * x + y * y);
     }
 };
 
@@ -54,8 +54,6 @@ static void scalarobjsort(benchmark::State &state)
 {
     // set up array
     std::vector<T> arr = init_data<T>(state.range(0));
-    //std::sort(arr.begin(), arr.end(), less_than_key<T>());
-    //std::reverse(arr.begin(), arr.end());
     std::vector<T> arr_bkp = arr;
     // benchmark
     for (auto _ : state) {
@@ -71,12 +69,10 @@ static void simdobjsort(benchmark::State &state)
 {
     // set up array
     std::vector<T> arr = init_data<T>(state.range(0));
-    //std::sort(arr.begin(), arr.end(), less_than_key<T>());
-    //std::reverse(arr.begin(), arr.end());
     std::vector<T> arr_bkp = arr;
     // benchmark
     for (auto _ : state) {
-        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> float {
+        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> double {
             return p.distance();
         });
         state.PauseTiming();
@@ -90,6 +86,7 @@ static void simdobjsort(benchmark::State &state)
 
 #define BENCHMARK_OBJSORT(func, T) \
     BENCHMARK_TEMPLATE(func, T) \
+            ->Arg(10e1) \
             ->Arg(10e2) \
             ->Arg(10e3) \
             ->Arg(10e4) \

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -3,10 +3,27 @@
 #include <stdint.h>
 #include <vector>
 #include <cstddef>
+#include <functional>
 
 #define XSS_EXPORT_SYMBOL __attribute__((visibility("default")))
 #define XSS_HIDE_SYMBOL __attribute__((visibility("hidden")))
 #define UNUSED(x) (void)(x)
+
+template <typename T>
+XSS_HIDE_SYMBOL void permute_array_in_place(T *A, std::vector<size_t> P)
+{
+    for (size_t i = 0; i < P.size(); i++) {
+        size_t curr = i;
+        size_t next = P[curr];
+        while (next != i) {
+            std::swap(A[curr], A[next]);
+            P[curr] = curr;
+            curr = next;
+            next = P[next];
+        }
+        P[curr] = curr;
+    }
+}
 
 namespace x86simdsort {
 
@@ -34,10 +51,24 @@ template <typename T>
 XSS_EXPORT_SYMBOL std::vector<size_t>
 argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
 
-// argselect
+// keyvalue sort
 template <typename T1, typename T2>
 XSS_EXPORT_SYMBOL void
 keyvalue_qsort(T1 *key, T2* val, size_t arrsize, bool hasnan = false);
+
+// sort an object
+template <typename T, typename F>
+XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, const F key_func)
+{
+    using return_type_of =
+            typename decltype(std::function {key_func})::result_type;
+    std::vector<return_type_of> keys(arrsize);
+    for (size_t ii = 0; ii < arrsize; ++ii) {
+        keys[ii] = key_func(arr[ii]);
+    }
+    std::vector<size_t> arg = x86simdsort::argsort(keys.data(), arrsize);
+    permute_array_in_place(arr, arg);
+}
 
 } // namespace x86simdsort
 #endif

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <cstddef>
 #include <functional>
+#include <numeric>
 
 #define XSS_EXPORT_SYMBOL __attribute__((visibility("default")))
 #define XSS_HIDE_SYMBOL __attribute__((visibility("hidden")))
@@ -53,10 +54,12 @@ XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, Func key_func)
         keys[ii] = key_func(arr[ii]);
     }
 
-    /* (2) Call argsort based on the keys */
-    std::vector<size_t> arg = argsort(keys.data(), arrsize);
+    /* (2) Call arg based on keys using the keyvalue sort */
+    std::vector<size_t> arg(arrsize);
+    std::iota(arg.begin(), arg.end(), 0);
+    keyvalue_qsort(keys.data(), arg.data(), arrsize);
 
-    /* (3) Permute array in-place */
+    /* (3) Permute obj array in-place */
     std::vector<bool> done(arrsize);
     for (size_t i = 0; i < arrsize; ++i)
     {

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -9,22 +9,6 @@
 #define XSS_HIDE_SYMBOL __attribute__((visibility("hidden")))
 #define UNUSED(x) (void)(x)
 
-template <typename T>
-XSS_HIDE_SYMBOL void permute_array_in_place(T *A, std::vector<size_t> P)
-{
-    for (size_t i = 0; i < P.size(); i++) {
-        size_t curr = i;
-        size_t next = P[curr];
-        while (next != i) {
-            std::swap(A[curr], A[next]);
-            P[curr] = curr;
-            curr = next;
-            next = P[next];
-        }
-        P[curr] = curr;
-    }
-}
-
 namespace x86simdsort {
 
 // quicksort
@@ -57,17 +41,40 @@ XSS_EXPORT_SYMBOL void
 keyvalue_qsort(T1 *key, T2* val, size_t arrsize, bool hasnan = false);
 
 // sort an object
-template <typename T, typename F>
-XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, const F key_func)
+template <typename T, typename Func>
+XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, Func key_func)
 {
+    /* (1) Create a vector a keys */
     using return_type_of =
             typename decltype(std::function {key_func})::result_type;
-    std::vector<return_type_of> keys(arrsize);
+    std::vector<return_type_of> keys;
+    keys.reserve(arrsize);
     for (size_t ii = 0; ii < arrsize; ++ii) {
         keys[ii] = key_func(arr[ii]);
     }
-    std::vector<size_t> arg = x86simdsort::argsort(keys.data(), arrsize);
-    permute_array_in_place(arr, arg);
+
+    /* (2) Call argsort based on the keys */
+    std::vector<size_t> arg = argsort(keys.data(), arrsize);
+
+    /* (3) Permute array in-place */
+    std::vector<bool> done(arrsize);
+    for (size_t i = 0; i < arrsize; ++i)
+    {
+        if (done[i])
+        {
+            continue;
+        }
+        done[i] = true;
+        size_t prev_j = i;
+        size_t j = arg[i];
+        while (i != j)
+        {
+            std::swap(arr[prev_j], arr[j]);
+            done[j] = true;
+            prev_j = j;
+            j = arg[j];
+        }
+    }
 }
 
 } // namespace x86simdsort

--- a/run-bench.py
+++ b/run-bench.py
@@ -37,6 +37,9 @@ if args.benchcompare:
     elif "keyvalue" in args.benchcompare:
         baseline = "scalarkvsort.*" + filterb
         contender = "simdkvsort.*" + filterb
+    elif "objsort" in args.benchcompare:
+        baseline = "scalarobjsort.*" + filterb
+        contender = "simdobjsort.*" + filterb
     else:
         parser.print_help(sys.stderr)
         parser.error("ERROR: Unknown argument '%s'" % args.benchcompare)


### PR DESCRIPTION
Benchmarks sorting an array of 2D and 3D cartesian coordinates: 

```
Benchmark                                Time             CPU   Iterations                                                                                          [35/27249]
--------------------------------------------------------------------------
scalarobjsort<Point2D>/1000          54107 ns        54100 ns        12908
scalarobjsort<Point2D>/10000       1172135 ns      1172105 ns          597
scalarobjsort<Point2D>/100000     14652163 ns     14651279 ns           48
scalarobjsort<Point2D>/1000000   174384347 ns    174363797 ns            4
scalarobjsort<Point2D>/10000000 2042991245 ns   2042818194 ns            1
scalarobjsort<Point3D>/1000          54005 ns        53998 ns        12886
scalarobjsort<Point3D>/10000       1240230 ns      1240178 ns          564
scalarobjsort<Point3D>/100000     15452639 ns     15451391 ns           45
scalarobjsort<Point3D>/1000000   188752147 ns    188723385 ns            4
scalarobjsort<Point3D>/10000000 2182026309 ns   2181807823 ns            1
RUNNING: ./benchexe --benchmark_filter=simdobjsort.* --benchmark_out=/tmp/tmpw4_wn2mr
2023-11-15T12:55:24-08:00
Running ./benchexe
Run on (20 X 1258 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1024 KiB (x10)
  L3 Unified 14080 KiB (x1)
Load Average: 0.72, 0.25, 0.17
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
simdobjsort<Point2D>/1000          14763 ns        14775 ns        47513
simdobjsort<Point2D>/10000        199342 ns       199357 ns         3474
simdobjsort<Point2D>/100000      3887458 ns      3887530 ns          181
simdobjsort<Point2D>/1000000    97432099 ns     97428446 ns            6
simdobjsort<Point2D>/10000000 2243062153 ns   2242956708 ns            1
simdobjsort<Point3D>/1000          16229 ns        16238 ns        43099
simdobjsort<Point3D>/10000        213301 ns       213314 ns         3274
simdobjsort<Point3D>/100000      4175434 ns      4175449 ns          168
simdobjsort<Point3D>/1000000   105489606 ns    105483514 ns            6
simdobjsort<Point3D>/10000000 2305455681 ns   2305295989 ns            1
Comparing scalarobjsort.* to simdobjsort.* (from ./benchexe)
Benchmark                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------
[scalarobjsort.* vs. simdobjsort.*]                -0.7272         -0.7269         54107         14763         54100         14775
[scalarobjsort.* vs. simdobjsort.*]                -0.8299         -0.8299       1172135        199342       1172105        199357
[scalarobjsort.* vs. simdobjsort.*]                -0.7347         -0.7347      14652163       3887458      14651279       3887530
[scalarobjsort.* vs. simdobjsort.*]                -0.4413         -0.4412     174384347      97432099     174363797      97428446
[scalarobjsort.* vs. simdobjsort.*]                +0.0979         +0.0980    2042991245    2243062153    2042818194    2242956708
[scalarobjsort.* vs. simdobjsort.*]                -0.6995         -0.6993         54005         16229         53998         16238
[scalarobjsort.* vs. simdobjsort.*]                -0.8280         -0.8280       1240230        213301       1240178        213314
[scalarobjsort.* vs. simdobjsort.*]                -0.7298         -0.7298      15452639       4175434      15451391       4175449
[scalarobjsort.* vs. simdobjsort.*]                -0.4411         -0.4411     188752147     105489606     188723385     105483514
[scalarobjsort.* vs. simdobjsort.*]                +0.0566         +0.0566    2182026309    2305455681    2181807823    2305295989
[scalarobjsort.* vs. simdobjsort.*]_pvalue          0.6776          0.6776      U Test, Repetitions: 10 vs 10
OVERALL_GEOMEAN                                    -0.6203         -0.6202             0             0             0             0


```