### PR TITLE
Improve key-value sort performance

### DIFF
--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -5,19 +5,19 @@ static constexpr char euclidean[] = "euclidean";
 static constexpr char taxicab[] = "taxicab";
 static constexpr char chebyshev[] = "chebyshev";
 
-template <const char* val>
+template <typename T, const char* val>
 struct Point3D {
-    double x;
-    double y;
-    double z;
+    T x;
+    T y;
+    T z;
     static constexpr std::string_view name {val};
     Point3D()
     {
-        x = (double)rand() / RAND_MAX;
-        y = (double)rand() / RAND_MAX;
-        z = (double)rand() / RAND_MAX;
+        x = (T)rand() / RAND_MAX;
+        y = (T)rand() / RAND_MAX;
+        z = (T)rand() / RAND_MAX;
     }
-    double distance()
+    T distance()
     {
         if constexpr (name == "x") {
             return x;
@@ -77,7 +77,7 @@ static void simdobjsort(benchmark::State &state)
     std::vector<T> arr_bkp = arr;
     // benchmark
     for (auto _ : state) {
-        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) -> double {
+        x86simdsort::object_qsort(arr.data(), arr.size(), [](T p) {
             return p.distance();
         });
         state.PauseTiming();
@@ -89,8 +89,8 @@ static void simdobjsort(benchmark::State &state)
     }
 }
 
-#define BENCHMARK_OBJSORT(func, T) \
-    BENCHMARK_TEMPLATE(func, T) \
+#define BENCHMARK_OBJSORT(func, T, type, dist) \
+    BENCHMARK_TEMPLATE(func, T<type,dist>) \
             ->Arg(10e1) \
             ->Arg(10e2) \
             ->Arg(10e3) \
@@ -98,11 +98,13 @@ static void simdobjsort(benchmark::State &state)
             ->Arg(10e5) \
             ->Arg(10e6);
 
-BENCHMARK_OBJSORT(simdobjsort, Point3D<x>)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D<x>)
-BENCHMARK_OBJSORT(simdobjsort, Point3D<taxicab>)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D<taxicab>)
-BENCHMARK_OBJSORT(simdobjsort, Point3D<euclidean>)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D<euclidean>)
-BENCHMARK_OBJSORT(simdobjsort, Point3D<chebyshev>)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D<chebyshev>)
+BENCHMARK_OBJSORT(simdobjsort, Point3D, double, x)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, x)
+BENCHMARK_OBJSORT(simdobjsort, Point3D, float, x)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D, float, x)
+BENCHMARK_OBJSORT(simdobjsort, Point3D, double, taxicab )
+BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, taxicab)
+BENCHMARK_OBJSORT(simdobjsort, Point3D, double, euclidean)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, euclidean)
+BENCHMARK_OBJSORT(simdobjsort, Point3D, double, chebyshev)
+BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, chebyshev)

--- a/run-bench.py
+++ b/run-bench.py
@@ -7,6 +7,7 @@ parser.add_argument('--branchcompare', action='store_true', help='Compare benchm
 parser.add_argument("-b", '--branch', type=str, default="main", required=False)
 parser.add_argument('--benchcompare', type=str, help='Compare simd bench with stdsort methods. Requires one of qsort, qselect, partialsort, argsort or argselect')
 parser.add_argument("-f", '--filter', type=str, required=False)
+parser.add_argument("-r", '--repeat', type=int, required=False)
 args = parser.parse_args()
 
 if len(sys.argv) == 1:
@@ -15,6 +16,9 @@ if len(sys.argv) == 1:
 filterb = ""
 if args.filter is not None:
     filterb = args.filter
+repeatnum = 1
+if args.repeat is not None:
+    repeatnum = args.repeat
 
 if args.benchcompare:
     baseline = ""
@@ -43,11 +47,11 @@ if args.benchcompare:
     else:
         parser.print_help(sys.stderr)
         parser.error("ERROR: Unknown argument '%s'" % args.benchcompare)
-    rc = subprocess.check_call("./scripts/bench-compare.sh '%s' '%s'" % (baseline, contender), shell=True)
+    rc = subprocess.check_call("./scripts/bench-compare.sh '%s' '%s' '%d'" % (baseline, contender, repeatnum), shell=True)
 
 if args.branchcompare:
     branch = args.branch
     if args.filter is None:
-        rc = subprocess.check_call("./scripts/branch-compare.sh '%s'" % (branch), shell=True)
+        rc = subprocess.check_call("./scripts/branch-compare.sh '%s' '%d'" % (branch, repeatnum), shell=True)
     else:
-        rc = subprocess.check_call("./scripts/branch-compare.sh '%s' '%s'" % (branch, args.filter), shell=True)
+        rc = subprocess.check_call("./scripts/branch-compare.sh '%s' '%s' '%d'" % (branch, args.filter, repeatnum), shell=True)

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -14,4 +14,4 @@ compare=$(realpath .bench/google-benchmark/tools/compare.py)
 meson setup -Dbuild_benchmarks=true --warnlevel 0 --buildtype release builddir-${branch}
 cd builddir-${branch}
 ninja
-$compare filters ./benchexe $1 $2
+$compare filters ./benchexe $1 $2 --benchmark_repetitions=$3

--- a/scripts/branch-compare.sh
+++ b/scripts/branch-compare.sh
@@ -44,10 +44,10 @@ build_branch $basebranch
 contender=$(realpath ${branch}/builddir/benchexe)
 baseline=$(realpath ${basebranch}/builddir/benchexe)
 
-if [ -z "$2" ]; then
+if [ -z "$3" ]; then
     echo "Comparing all benchmarks .."
-    $compare benchmarks $baseline $contender
+    $compare benchmarks $baseline $contender --benchmark_repetitions=$2
 else
     echo "Comparing benchmark $2 .."
-    $compare benchmarksfiltered $baseline $2 $contender $2
+    $compare benchmarksfiltered $baseline $2 $contender $2 --benchmark_repetitions=$3
 fi

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -32,6 +32,7 @@ template <>
 struct zmm_vector<int32_t> {
     using type_t = int32_t;
     using reg_t = __m512i;
+    using regi_t = __m512i;
     using halfreg_t = __m256i;
     using opmask_t = __mmask16;
     static const uint8_t numlanes = 16;
@@ -64,6 +65,10 @@ struct zmm_vector<int32_t> {
     static opmask_t ge(reg_t x, reg_t y)
     {
         return _mm512_cmp_epi32_mask(x, y, _MM_CMPINT_NLT);
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_epi32_mask(x, y);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -123,6 +128,40 @@ struct zmm_vector<int32_t> {
     {
         return _mm512_set1_epi32(v);
     }
+    static regi_t seti(int v1,
+                       int v2,
+                       int v3,
+                       int v4,
+                       int v5,
+                       int v6,
+                       int v7,
+                       int v8,
+                       int v9,
+                       int v10,
+                       int v11,
+                       int v12,
+                       int v13,
+                       int v14,
+                       int v15,
+                       int v16)
+    {
+        return _mm512_set_epi32(v1,
+                                v2,
+                                v3,
+                                v4,
+                                v5,
+                                v6,
+                                v7,
+                                v8,
+                                v9,
+                                v10,
+                                v11,
+                                v12,
+                                v13,
+                                v14,
+                                v15,
+                                v16);
+    }
     template <uint8_t mask>
     static reg_t shuffle(reg_t zmm)
     {
@@ -171,6 +210,7 @@ template <>
 struct zmm_vector<uint32_t> {
     using type_t = uint32_t;
     using reg_t = __m512i;
+    using regi_t = __m512i;
     using halfreg_t = __m256i;
     using opmask_t = __mmask16;
     static const uint8_t numlanes = 16;
@@ -213,6 +253,10 @@ struct zmm_vector<uint32_t> {
     static opmask_t ge(reg_t x, reg_t y)
     {
         return _mm512_cmp_epu32_mask(x, y, _MM_CMPINT_NLT);
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_epu32_mask(x, y);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -262,6 +306,40 @@ struct zmm_vector<uint32_t> {
     {
         return _mm512_set1_epi32(v);
     }
+    static regi_t seti(int v1,
+                       int v2,
+                       int v3,
+                       int v4,
+                       int v5,
+                       int v6,
+                       int v7,
+                       int v8,
+                       int v9,
+                       int v10,
+                       int v11,
+                       int v12,
+                       int v13,
+                       int v14,
+                       int v15,
+                       int v16)
+    {
+        return _mm512_set_epi32(v1,
+                                v2,
+                                v3,
+                                v4,
+                                v5,
+                                v6,
+                                v7,
+                                v8,
+                                v9,
+                                v10,
+                                v11,
+                                v12,
+                                v13,
+                                v14,
+                                v15,
+                                v16);
+    }
     template <uint8_t mask>
     static reg_t shuffle(reg_t zmm)
     {
@@ -310,6 +388,7 @@ template <>
 struct zmm_vector<float> {
     using type_t = float;
     using reg_t = __m512;
+    using regi_t = __m512i;
     using halfreg_t = __m256;
     using opmask_t = __mmask16;
     static const uint8_t numlanes = 16;
@@ -342,6 +421,10 @@ struct zmm_vector<float> {
     static opmask_t ge(reg_t x, reg_t y)
     {
         return _mm512_cmp_ps_mask(x, y, _CMP_GE_OQ);
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_ps_mask(x, y);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -414,6 +497,40 @@ struct zmm_vector<float> {
     static reg_t set1(type_t v)
     {
         return _mm512_set1_ps(v);
+    }
+    static regi_t seti(int v1,
+                       int v2,
+                       int v3,
+                       int v4,
+                       int v5,
+                       int v6,
+                       int v7,
+                       int v8,
+                       int v9,
+                       int v10,
+                       int v11,
+                       int v12,
+                       int v13,
+                       int v14,
+                       int v15,
+                       int v16)
+    {
+        return _mm512_set_epi32(v1,
+                                v2,
+                                v3,
+                                v4,
+                                v5,
+                                v6,
+                                v7,
+                                v8,
+                                v9,
+                                v10,
+                                v11,
+                                v12,
+                                v13,
+                                v14,
+                                v15,
+                                v16);
     }
     template <uint8_t mask>
     static reg_t shuffle(reg_t zmm)

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -267,12 +267,17 @@ template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
 avx512_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
 {
-    using keytype = typename std::conditional<sizeof(T1) == sizeof(int32_t),
-                                              ymm_vector<T1>,
-                                              zmm_vector<T1>>::type;
-    using valtype = typename std::conditional<sizeof(T2) == sizeof(int32_t),
-                                              ymm_vector<T2>,
-                                              zmm_vector<T2>>::type;
+    using keytype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T1) == sizeof(int32_t),
+                                      ymm_vector<T1>,
+                                      zmm_vector<T1>>::type;
+    using valtype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T2) == sizeof(int32_t),
+                                      ymm_vector<T2>,
+                                      zmm_vector<T2>>::type;
+
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T1>) {
             arrsize_t nan_count = 0;

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -248,7 +248,7 @@ X86_SIMD_SORT_INLINE void qsort_64bit_(type1_t *keys,
         return;
     }
 
-    type1_t pivot = get_pivot<vtype1>(keys, left, right);
+    type1_t pivot = get_pivot_blocks<vtype1>(keys, left, right);
     type1_t smallest = vtype1::type_max();
     type1_t biggest = vtype1::type_min();
     arrsize_t pivot_index = partition_avx512<vtype1, vtype2>(

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -1,6 +1,7 @@
 #ifndef XSS_KEYVALUE_NETWORKS
 #define XSS_KEYVALUE_NETWORKS
 
+#include "avx512-32bit-qsort.hpp"
 #include "avx512-64bit-qsort.hpp"
 #include "avx2-64bit-qsort.hpp"
 

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -45,7 +45,112 @@ template <typename vtype1,
           typename vtype2,
           typename reg_t = typename vtype1::reg_t,
           typename index_type = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE reg_t sort_zmm_64bit(reg_t key_zmm, index_type &index_zmm)
+X86_SIMD_SORT_INLINE reg_t sort_reg_16lanes(reg_t key_zmm,
+                                            index_type &index_zmm)
+{
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
+            0xAAAA);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(0, 1, 2, 3)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(0, 1, 2, 3)>(index_zmm),
+            0xCCCC);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
+            0xAAAA);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_3), key_zmm),
+            index_zmm,
+            vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_3), index_zmm),
+            0xF0F0);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
+            0xCCCC);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
+            0xAAAA);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_5), key_zmm),
+            index_zmm,
+            vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_5), index_zmm),
+            0xFF00);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_6), key_zmm),
+            index_zmm,
+            vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_6), index_zmm),
+            0xF0F0);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
+            0xCCCC);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
+            0xAAAA);
+    return key_zmm;
+}
+
+// Assumes zmm is bitonic and performs a recursive half cleaner
+template <typename vtype1,
+          typename vtype2,
+          typename reg_t = typename vtype1::reg_t,
+          typename index_type = typename vtype2::reg_t>
+X86_SIMD_SORT_INLINE reg_t bitonic_merge_reg_16lanes(reg_t key_zmm,
+                                                     index_type &index_zmm)
+{
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_7), key_zmm),
+            index_zmm,
+            vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_7), index_zmm),
+            0xFF00);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_6), key_zmm),
+            index_zmm,
+            vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_6), index_zmm),
+            0xF0F0);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
+            0xCCCC);
+    key_zmm = cmp_merge<vtype1, vtype2>(
+            key_zmm,
+            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            index_zmm,
+            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
+            0xAAAA);
+    return key_zmm;
+}
+
+template <typename vtype1,
+          typename vtype2,
+          typename reg_t = typename vtype1::reg_t,
+          typename index_type = typename vtype2::reg_t>
+X86_SIMD_SORT_INLINE reg_t sort_reg_8lanes(reg_t key_zmm, index_type &index_zmm)
 {
     const typename vtype1::regi_t rev_index1 = vtype1::seti(NETWORK_64BIT_2);
     const typename vtype2::regi_t rev_index2 = vtype2::seti(NETWORK_64BIT_2);
@@ -93,8 +198,8 @@ template <typename vtype1,
           typename vtype2,
           typename reg_t = typename vtype1::reg_t,
           typename index_type = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE reg_t bitonic_merge_zmm_64bit(reg_t key_zmm,
-                                                   index_type &index_zmm)
+X86_SIMD_SORT_INLINE reg_t bitonic_merge_reg_8lanes(reg_t key_zmm,
+                                                    index_type &index_zmm)
 {
 
     // 1) half_cleaner[8]: compare 0-4, 1-5, 2-6, 3-7
@@ -128,10 +233,13 @@ bitonic_merge_dispatch(typename keyType::reg_t &key,
 {
     constexpr int numlanes = keyType::numlanes;
     if constexpr (numlanes == 8) {
-        key = bitonic_merge_zmm_64bit<keyType, valueType>(key, value);
+        key = bitonic_merge_reg_8lanes<keyType, valueType>(key, value);
+    }
+    else if constexpr (numlanes == 16) {
+        key = bitonic_merge_reg_16lanes<keyType, valueType>(key, value);
     }
     else {
-        static_assert(numlanes == -1, "should not reach here");
+        static_assert(numlanes == -1, "No implementation");
         UNUSED(key);
         UNUSED(value);
     }
@@ -143,10 +251,13 @@ X86_SIMD_SORT_INLINE void sort_vec_dispatch(typename keyType::reg_t &key,
 {
     constexpr int numlanes = keyType::numlanes;
     if constexpr (numlanes == 8) {
-        key = sort_zmm_64bit<keyType, valueType>(key, value);
+        key = sort_reg_8lanes<keyType, valueType>(key, value);
+    }
+    else if constexpr (numlanes == 16) {
+        key = sort_reg_16lanes<keyType, valueType>(key, value);
     }
     else {
-        static_assert(numlanes == -1, "should not reach here");
+        static_assert(numlanes == -1, "No implementation");
         UNUSED(key);
         UNUSED(value);
     }


### PR DESCRIPTION
1. AVX-512 32-bit key value sort now uses zmm registers exclusively
2. Added `partition_avx512_unrolled` function
3. Use `get_pivot_blocks` function in key-value sort. 

Performance numbers: 

```
Benchmark                                                                  Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------------------------
[simdkvsort/random_1m vs. simdkvsort/random_1m]/uint64_t                -0.2048         -0.2048      21833844      17362725      21833373      17361179
[simdkvsort/random_1m vs. simdkvsort/random_1m]/int64_t                 -0.2099         -0.2099      21922325      17320157      21919807      17319054
[simdkvsort/random_1m vs. simdkvsort/random_1m]/double                  -0.2257         -0.2258      20498044      15871414      20496653      15869322
[simdkvsort/random_1m vs. simdkvsort/random_1m]/uint32_t                -0.5045         -0.5045      16658607       8254529      16657580       8253890
[simdkvsort/random_1m vs. simdkvsort/random_1m]/int32_t                 -0.5009         -0.5009      16618624       8293955      16617563       8293402
[simdkvsort/random_1m vs. simdkvsort/random_1m]/float                   -0.4644         -0.4645      16973247       9090381      16972334       9089449
OVERALL_GEOMEAN                                                         -0.3668         -0.3669             0             0             0             0

```
