### PR TITLE
Build fix on macOS 64-bit

### DIFF
--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -595,10 +595,17 @@ avx2_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false)
                                               avx2_half_vector<T>,
                                               avx2_vector<T>>::type;
 
+#ifdef __APPLE__
+    using argtype =
+            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
+                                      avx2_half_vector<uint32_t>,
+                                      avx2_vector<uint64_t>>::type;
+#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       avx2_half_vector<arrsize_t>,
                                       avx2_vector<arrsize_t>>::type;
+#endif
 
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {
@@ -685,10 +692,17 @@ X86_SIMD_SORT_INLINE void avx2_argselect(T *arr,
                                               avx2_half_vector<T>,
                                               avx2_vector<T>>::type;
 
+#ifdef __APPLE__
+    using argtype =
+            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
+                                      avx2_half_vector<uint32_t>,
+                                      avx2_vector<uint64_t>>::type;
+#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       avx2_half_vector<arrsize_t>,
                                       avx2_vector<arrsize_t>>::type;
+#endif
 
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -65,7 +65,7 @@
 #define UNLIKELY(x) (x)
 #endif
 
-#if __GNUC__ >= 8
+#if __GNUC__ >= 8 and !defined(__SANITIZE_ADDRESS__)
 #define X86_SIMD_SORT_UNROLL_LOOP(num) PRAGMA(GCC unroll num)
 #else
 #define X86_SIMD_SORT_UNROLL_LOOP(num)

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -328,7 +328,8 @@ bitonic_merge_dispatch(typename keyType::reg_t &key,
         key = bitonic_merge_ymm_64bit<keyType, valueType>(key, value);
     }
     else {
-        static_assert(always_false<keyType>, "bitonic_merge_dispatch: No implementation");
+        static_assert(always_false<keyType>,
+                      "bitonic_merge_dispatch: No implementation");
         UNUSED(key);
         UNUSED(value);
     }
@@ -349,7 +350,8 @@ X86_SIMD_SORT_INLINE void sort_vec_dispatch(typename keyType::reg_t &key,
         key = sort_ymm_64bit<keyType, valueType>(key, value);
     }
     else {
-        static_assert(always_false<keyType>, "sort_vec_dispatch: No implementation");
+        static_assert(always_false<keyType>,
+                      "sort_vec_dispatch: No implementation");
         UNUSED(key);
         UNUSED(value);
     }
@@ -584,8 +586,9 @@ X86_SIMD_SORT_INLINE void kvsort_n_vec(typename keyType::type_t *keys,
 }
 
 template <typename keyType, typename indexType, int maxN>
-X86_SIMD_SORT_INLINE void
-argsort_n(typename keyType::type_t *keys, arrsize_t *indices, int N)
+X86_SIMD_SORT_INLINE void argsort_n(typename keyType::type_t *keys,
+                                    typename indexType::type_t *indices,
+                                    int N)
 {
     static_assert(keyType::numlanes == indexType::numlanes,
                   "invalid pairing of value/index types");


### PR DESCRIPTION
compiler on macOS doesn't implicitly convert `zmm_vector<size_t>` to `zmm_vector<uint64_t>`