### PR TITLE
Fix more build issues on macOS

### DIFF
--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -912,6 +912,19 @@ struct zmm_vector<uint64_t> {
                 left_addr, right_addr, k, reg);
     }
 };
+
+/*
+ * workaround on 64-bit macOS which defines size_t as unsigned long and defines
+ * uint64_t as unsigned long long, both of which are 8 bytes
+ */
+#if defined(__APPLE__) && defined(__x86_64__)
+static_assert(sizeof(size_t) == sizeof(uint64_t),
+              "Size of size_t and uint64_t are not the same");
+template <>
+struct zmm_vector<size_t> : public zmm_vector<uint64_t> {
+};
+#endif
+
 template <>
 struct zmm_vector<double> {
     using type_t = double;

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -559,19 +559,10 @@ avx512_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false)
                                               ymm_vector<T>,
                                               zmm_vector<T>>::type;
 
-/* Workaround for NumPy failed build on macOS x86_64: implicit instantiation of
- * undefined template 'zmm_vector<unsigned long>'*/
-#ifdef __APPLE__
-    using argtype =
-            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
-                                      ymm_vector<uint32_t>,
-                                      zmm_vector<uint64_t>>::type;
-#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       ymm_vector<arrsize_t>,
                                       zmm_vector<arrsize_t>>::type;
-#endif
 
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {
@@ -605,18 +596,10 @@ avx2_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false)
                                               avx2_half_vector<T>,
                                               avx2_vector<T>>::type;
 
-#ifdef __APPLE__
-    using argtype =
-            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
-                                      avx2_half_vector<uint32_t>,
-                                      avx2_vector<uint64_t>>::type;
-#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       avx2_half_vector<arrsize_t>,
                                       avx2_vector<arrsize_t>>::type;
-#endif
-
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {
             if ((hasnan) && (array_has_nan<vectype>(arr, arrsize))) {
@@ -653,19 +636,10 @@ X86_SIMD_SORT_INLINE void avx512_argselect(T *arr,
                                               ymm_vector<T>,
                                               zmm_vector<T>>::type;
 
-/* Workaround for NumPy failed build on macOS x86_64: implicit instantiation of
- * undefined template 'zmm_vector<unsigned long>'*/
-#ifdef __APPLE__
-    using argtype =
-            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
-                                      ymm_vector<uint32_t>,
-                                      zmm_vector<uint64_t>>::type;
-#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       ymm_vector<arrsize_t>,
                                       zmm_vector<arrsize_t>>::type;
-#endif
 
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {
@@ -702,17 +676,10 @@ X86_SIMD_SORT_INLINE void avx2_argselect(T *arr,
                                               avx2_half_vector<T>,
                                               avx2_vector<T>>::type;
 
-#ifdef __APPLE__
-    using argtype =
-            typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
-                                      avx2_half_vector<uint32_t>,
-                                      avx2_vector<uint64_t>>::type;
-#else
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       avx2_half_vector<arrsize_t>,
                                       avx2_vector<arrsize_t>>::type;
-#endif
 
     if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -291,14 +291,15 @@ X86_SIMD_SORT_INLINE arrsize_t partition_avx512(type_t *arr,
 template <typename vtype,
           typename argtype,
           int num_unroll,
-          typename type_t = typename vtype::type_t>
-X86_SIMD_SORT_INLINE arrsize_t partition_avx512_unrolled(type_t *arr,
-                                                         arrsize_t *arg,
-                                                         arrsize_t left,
-                                                         arrsize_t right,
-                                                         type_t pivot,
-                                                         type_t *smallest,
-                                                         type_t *biggest)
+          typename type_t = typename vtype::type_t,
+          typename argtype_t = typename argtype::type_t>
+X86_SIMD_SORT_INLINE arrsize_t argpartition_unrolled(type_t *arr,
+                                                     argtype_t *arg,
+                                                     arrsize_t left,
+                                                     arrsize_t right,
+                                                     type_t pivot,
+                                                     type_t *smallest,
+                                                     type_t *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype::numlanes) {
         return partition_avx512<vtype, argtype>(
@@ -422,9 +423,12 @@ X86_SIMD_SORT_INLINE arrsize_t partition_avx512_unrolled(type_t *arr,
     return l_store;
 }
 
-template <typename vtype, typename type_t>
+template <typename vtype,
+          typename argtype,
+          typename type_t = typename vtype::type_t,
+          typename argtype_t = typename argtype::type_t>
 X86_SIMD_SORT_INLINE type_t get_pivot_64bit(type_t *arr,
-                                            arrsize_t *arg,
+                                            argtype_t *arg,
                                             const arrsize_t left,
                                             const arrsize_t right)
 {
@@ -468,9 +472,12 @@ X86_SIMD_SORT_INLINE type_t get_pivot_64bit(type_t *arr,
     }
 }
 
-template <typename vtype, typename argtype, typename type_t>
+template <typename vtype,
+          typename argtype,
+          typename type_t = typename vtype::type_t,
+          typename argtype_t = typename argtype::type_t>
 X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
-                                         arrsize_t *arg,
+                                         argtype_t *arg,
                                          arrsize_t left,
                                          arrsize_t right,
                                          arrsize_t max_iters)
@@ -490,10 +497,10 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
                 arr, arg + left, (int32_t)(right + 1 - left));
         return;
     }
-    type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
+    type_t pivot = get_pivot_64bit<vtype, argtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         argsort_64bit_<vtype, argtype>(
@@ -503,9 +510,12 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
                 arr, arg, pivot_index, right, max_iters - 1);
 }
 
-template <typename vtype, typename argtype, typename type_t>
+template <typename vtype,
+          typename argtype,
+          typename type_t = typename vtype::type_t,
+          typename argtype_t = typename argtype::type_t>
 X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
-                                           arrsize_t *arg,
+                                           argtype_t *arg,
                                            arrsize_t pos,
                                            arrsize_t left,
                                            arrsize_t right,
@@ -526,10 +536,10 @@ X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
                 arr, arg + left, (int32_t)(right + 1 - left));
         return;
     }
-    type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
+    type_t pivot = get_pivot_64bit<vtype, argtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         argselect_64bit_<vtype, argtype>(

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -291,15 +291,14 @@ X86_SIMD_SORT_INLINE arrsize_t partition_avx512(type_t *arr,
 template <typename vtype,
           typename argtype,
           int num_unroll,
-          typename type_t = typename vtype::type_t,
-          typename argtype_t = typename argtype::type_t>
-X86_SIMD_SORT_INLINE arrsize_t argpartition_unrolled(type_t *arr,
-                                                     argtype_t *arg,
-                                                     arrsize_t left,
-                                                     arrsize_t right,
-                                                     type_t pivot,
-                                                     type_t *smallest,
-                                                     type_t *biggest)
+          typename type_t = typename vtype::type_t>
+X86_SIMD_SORT_INLINE arrsize_t partition_avx512_unrolled(type_t *arr,
+                                                         arrsize_t *arg,
+                                                         arrsize_t left,
+                                                         arrsize_t right,
+                                                         type_t pivot,
+                                                         type_t *smallest,
+                                                         type_t *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype::numlanes) {
         return partition_avx512<vtype, argtype>(
@@ -423,12 +422,9 @@ X86_SIMD_SORT_INLINE arrsize_t argpartition_unrolled(type_t *arr,
     return l_store;
 }
 
-template <typename vtype,
-          typename argtype,
-          typename type_t = typename vtype::type_t,
-          typename argtype_t = typename argtype::type_t>
+template <typename vtype, typename type_t>
 X86_SIMD_SORT_INLINE type_t get_pivot_64bit(type_t *arr,
-                                            argtype_t *arg,
+                                            arrsize_t *arg,
                                             const arrsize_t left,
                                             const arrsize_t right)
 {
@@ -472,12 +468,9 @@ X86_SIMD_SORT_INLINE type_t get_pivot_64bit(type_t *arr,
     }
 }
 
-template <typename vtype,
-          typename argtype,
-          typename type_t = typename vtype::type_t,
-          typename argtype_t = typename argtype::type_t>
+template <typename vtype, typename argtype, typename type_t>
 X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
-                                         argtype_t *arg,
+                                         arrsize_t *arg,
                                          arrsize_t left,
                                          arrsize_t right,
                                          arrsize_t max_iters)
@@ -497,10 +490,10 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
                 arr, arg + left, (int32_t)(right + 1 - left));
         return;
     }
-    type_t pivot = get_pivot_64bit<vtype, argtype>(arr, arg, left, right);
+    type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         argsort_64bit_<vtype, argtype>(
@@ -510,12 +503,9 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
                 arr, arg, pivot_index, right, max_iters - 1);
 }
 
-template <typename vtype,
-          typename argtype,
-          typename type_t = typename vtype::type_t,
-          typename argtype_t = typename argtype::type_t>
+template <typename vtype, typename argtype, typename type_t>
 X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
-                                           argtype_t *arg,
+                                           arrsize_t *arg,
                                            arrsize_t pos,
                                            arrsize_t left,
                                            arrsize_t right,
@@ -536,10 +526,10 @@ X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
                 arr, arg + left, (int32_t)(right + 1 - left));
         return;
     }
-    type_t pivot = get_pivot_64bit<vtype, argtype>(arr, arg, left, right);
+    type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         argselect_64bit_<vtype, argtype>(

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -90,15 +90,7 @@ constexpr bool always_false = false;
 #define NETWORK_32BIT_6 11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4
 #define NETWORK_32BIT_7 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8
 
-/*
- * workaround on 64-bit macOS which defines size_t as unsigned long and defines
- * uint64_t as unsigned long long, both of which are 8 bytes
- */
-#if defined(__APPLE__) && defined(__x86_64__)
-typedef uint64_t arrsize_t;
-#else
 typedef size_t arrsize_t;
-#endif
 
 template <typename type>
 struct zmm_vector;

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -90,7 +90,15 @@ constexpr bool always_false = false;
 #define NETWORK_32BIT_6 11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4
 #define NETWORK_32BIT_7 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8
 
+/*
+ * workaround on 64-bit macOS which defines size_t as unsigned long and defines
+ * uint64_t as unsigned long long, both of which are 8 bytes
+ */
+#if defined(__APPLE__) && defined(__x86_64__)
+typedef uint64_t arrsize_t;
+#else
 typedef size_t arrsize_t;
+#endif
 
 template <typename type>
 struct zmm_vector;

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -442,7 +442,7 @@ bitonic_fullmerge_n_vec(typename keyType::reg_t *keys,
 
 template <typename keyType, typename indexType, int numVecs>
 X86_SIMD_SORT_INLINE void argsort_n_vec(typename keyType::type_t *keys,
-                                        typename indexType::type_t *indices,
+                                        arrsize_t *indices,
                                         int N)
 {
     using kreg_t = typename keyType::reg_t;
@@ -587,7 +587,7 @@ X86_SIMD_SORT_INLINE void kvsort_n_vec(typename keyType::type_t *keys,
 
 template <typename keyType, typename indexType, int maxN>
 X86_SIMD_SORT_INLINE void argsort_n(typename keyType::type_t *keys,
-                                    typename indexType::type_t *indices,
+                                    arrsize_t *indices,
                                     int N)
 {
     static_assert(keyType::numlanes == indexType::numlanes,


### PR DESCRIPTION
on 64-bit macOS, `size_t` is `unsigned long` and `uint64_t `is mapped to `unsigned long long` (both of which are 8 bytes in size). This causes build failures because the compiler refuses to map  `zmm_vector<size_t>` to `zmm_vector<uint64_t>`. 