### PR TITLE
Use uint32_t instead of size_t for object sort

### DIFF
--- a/.github/workflows/build-numpy.yml
+++ b/.github/workflows/build-numpy.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Install NumPy dependencies
       working-directory: ${{ github.workspace }}/numpy
       run: |
-        pip install -r build_requirements.txt
-        pip install -r test_requirements.txt
+        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/test_requirements.txt
 
     - name: Update x86-simd-sort
       working-directory: ${{ github.workspace }}/numpy
@@ -116,8 +116,8 @@ jobs:
     - name: Install NumPy dependencies
       working-directory: ${{ github.workspace }}/numpy
       run: |
-        pip install -r build_requirements.txt
-        pip install -r test_requirements.txt
+        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/test_requirements.txt
 
     - name: Update x86-simd-sort
       working-directory: ${{ github.workspace }}/numpy

--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -26,7 +26,7 @@ struct Point3D {
             return std::sqrt(x * x + y * y + z * z);
         }
         else if constexpr (name == "taxicab") {
-            return abs(x) + abs(y) + abs(z);
+            return std::abs(x) + std::abs(y) + std::abs(z);
         }
         else if constexpr (name == "chebyshev") {
             return std::max(std::max(x, y), z);
@@ -98,13 +98,15 @@ static void simdobjsort(benchmark::State &state)
             ->Arg(10e5) \
             ->Arg(10e6);
 
-BENCHMARK_OBJSORT(simdobjsort, Point3D, double, x)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, x)
-BENCHMARK_OBJSORT(simdobjsort, Point3D, float, x)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D, float, x)
-BENCHMARK_OBJSORT(simdobjsort, Point3D, double, taxicab )
-BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, taxicab)
-BENCHMARK_OBJSORT(simdobjsort, Point3D, double, euclidean)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, euclidean)
-BENCHMARK_OBJSORT(simdobjsort, Point3D, double, chebyshev)
-BENCHMARK_OBJSORT(scalarobjsort, Point3D, double, chebyshev)
+#define BENCH_ALL(dtype) \
+    BENCHMARK_OBJSORT(simdobjsort, Point3D, dtype, x) \
+    BENCHMARK_OBJSORT(scalarobjsort, Point3D, dtype, x) \
+    BENCHMARK_OBJSORT(simdobjsort, Point3D, dtype, taxicab ) \
+    BENCHMARK_OBJSORT(scalarobjsort, Point3D, dtype, taxicab) \
+    BENCHMARK_OBJSORT(simdobjsort, Point3D, dtype, euclidean) \
+    BENCHMARK_OBJSORT(scalarobjsort, Point3D, dtype, euclidean) \
+    BENCHMARK_OBJSORT(simdobjsort, Point3D, dtype, chebyshev) \
+    BENCHMARK_OBJSORT(scalarobjsort, Point3D, dtype, chebyshev) \
+
+BENCH_ALL(double)
+BENCH_ALL(float)

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -43,7 +43,7 @@ keyvalue_qsort(T1 *key, T2* val, size_t arrsize, bool hasnan = false);
 
 // sort an object
 template <typename T, typename Func>
-XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, Func key_func)
+XSS_EXPORT_SYMBOL void object_qsort(T *arr, uint32_t arrsize, Func key_func)
 {
     /* (1) Create a vector a keys */
     using return_type_of =
@@ -55,9 +55,9 @@ XSS_EXPORT_SYMBOL void object_qsort(T *arr, size_t arrsize, Func key_func)
     }
 
     /* (2) Call arg based on keys using the keyvalue sort */
-    std::vector<size_t> arg(arrsize);
+    std::vector<uint32_t> arg(arrsize);
     std::iota(arg.begin(), arg.end(), 0);
-    keyvalue_qsort(keys.data(), arg.data(), arrsize);
+    x86simdsort::keyvalue_qsort(keys.data(), arg.data(), arrsize);
 
     /* (3) Permute obj array in-place */
     std::vector<bool> done(arrsize);


### PR DESCRIPTION
Improves performance especially when the metric to sort is a 32-bit dtype: 

```
Benchmark                                                                            Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
[scalarobjsort.*float vs. simdobjsort.*float],x>>/100                             +0.0933         +0.0947          1419          1551          1421          1555
[scalarobjsort.*float vs. simdobjsort.*float],x>>/1000                            -0.3962         -0.3965         15418          9309         15431          9313
[scalarobjsort.*float vs. simdobjsort.*float],x>>/10000                           -0.8120         -0.8119        576470        108403        576505        108422
[scalarobjsort.*float vs. simdobjsort.*float],x>>/100000                          -0.7364         -0.7364       7084507       1867259       7084966       1867333
[scalarobjsort.*float vs. simdobjsort.*float],x>>/1000000                         -0.5463         -0.5463      86243039      39130817      86238537      39128228
[scalarobjsort.*float vs. simdobjsort.*float],x>>/10000000                        +0.0628         +0.0628    1018919772    1082899576    1018866896    1082838013
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/100                       -0.2089         -0.2088          2028          1604          2031          1607
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/1000                      -0.6529         -0.6529         28076          9744         28085          9749
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/10000                     -0.8666         -0.8666        852263        113676        852319        113696
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/100000                    -0.8211         -0.8211      10474638       1873979      10474826       1873929
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/1000000                   -0.6921         -0.6921     126190844      38854176     126185333      38851333
[scalarobjsort.*float vs. simdobjsort.*float],taxicab>>/10000000                  -0.2535         -0.2535    1460305765    1090189561    1460270229    1090125905
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/100                     -0.3014         -0.3004          2273          1588          2275          1591
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/1000                    -0.7477         -0.7476         36658          9247         36672          9254
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/10000                   -0.8951         -0.8951       1073122        112611       1073198        112625
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/100000                  -0.8582         -0.8581      13320127       1889451      13320036       1889454
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/1000000                 -0.7599         -0.7599     162466510      39011741     162464089      39008496
[scalarobjsort.*float vs. simdobjsort.*float],euclidean>>/10000000                -0.4183         -0.4183    1865672145    1085333325    1865605675    1085226497
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/100                     -0.1406         -0.1400          1822          1566          1825          1570
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/1000                    -0.6403         -0.6403         25983          9346         25999          9352
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/10000                   -0.8596         -0.8596        808734        113518        808769        113526
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/100000                  -0.8172         -0.8172      10281025       1879824      10281239       1879870
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/1000000                 -0.6841         -0.6841     122766074      38785146     122764627      38783435
[scalarobjsort.*float vs. simdobjsort.*float],chebyshev>>/10000000                -0.2506         -0.2507    1441875046    1080508739    1441843964    1080441164
OVERALL_GEOMEAN                                                                   -0.6447         -0.6447             0             0             0             0

```