### PR TITLE
New pivot selection algorithm to better handle many special cases

### DIFF
--- a/src/avx2-32bit-qsort.hpp
+++ b/src/avx2-32bit-qsort.hpp
@@ -86,6 +86,11 @@ struct avx2_vector<int32_t> {
     {
         return _mm256_set1_epi32(type_max());
     } // TODO: this should broadcast bits as is?
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allOnes = seti(-1, -1, -1, -1, -1, -1, -1, -1);
+        return _mm256_xor_si256(x, allOnes);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
@@ -204,6 +209,9 @@ struct avx2_vector<int32_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -241,6 +249,11 @@ struct avx2_vector<uint32_t> {
     static reg_t zmm_max()
     {
         return _mm256_set1_epi32(type_max());
+    }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allOnes = seti(-1, -1, -1, -1, -1, -1, -1, -1);
+        return _mm256_xor_si256(x, allOnes);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -349,6 +362,9 @@ struct avx2_vector<uint32_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -387,7 +403,11 @@ struct avx2_vector<float> {
     {
         return _mm256_set1_ps(type_max());
     }
-
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allOnes = seti(-1, -1, -1, -1, -1, -1, -1, -1);
+        return _mm256_xor_si256(x, allOnes);
+    }
     static ymmi_t
     seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
@@ -513,6 +533,9 @@ struct avx2_vector<float> {
     static __m256i cast_to(reg_t v)
     {
         return _mm256_castps_si256(v);
+    }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -68,12 +68,17 @@ struct avx2_vector<int64_t> {
     {
         return _mm256_set1_epi64x(type_max());
     } // TODO: this should broadcast bits as is?
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        return _mm256_xor_si256(x, allTrue);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask_64bit(mask);
     }
-    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    static ymmi_t seti(int64_t v1, int64_t v2, int64_t v3, int64_t v4)
     {
         return _mm256_set_epi64x(v1, v2, v3, v4);
     }
@@ -209,6 +214,9 @@ struct avx2_vector<int64_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
+    }
 };
 template <>
 struct avx2_vector<uint64_t> {
@@ -239,12 +247,17 @@ struct avx2_vector<uint64_t> {
     {
         return _mm256_set1_epi64x(type_max());
     }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        return _mm256_xor_si256(x, allTrue);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask_64bit(mask);
     }
-    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    static ymmi_t seti(int64_t v1, int64_t v2, int64_t v3, int64_t v4)
     {
         return _mm256_set_epi64x(v1, v2, v3, v4);
     }
@@ -378,6 +391,9 @@ struct avx2_vector<uint64_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
+    }
 };
 
 /*
@@ -421,6 +437,11 @@ struct avx2_vector<double> {
     {
         return _mm256_set1_pd(type_max());
     }
+    static opmask_t knot_opmask(opmask_t x)
+    {
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        return _mm256_xor_si256(x, allTrue);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
@@ -440,7 +461,7 @@ struct avx2_vector<double> {
             static_assert(type == (0x01 | 0x80), "should not reach here");
         }
     }
-    static ymmi_t seti(int v1, int v2, int v3, int v4)
+    static ymmi_t seti(int64_t v1, int64_t v2, int64_t v3, int64_t v4)
     {
         return _mm256_set_epi64x(v1, v2, v3, v4);
     }
@@ -570,6 +591,9 @@ struct avx2_vector<double> {
     static __m256i cast_to(reg_t v)
     {
         return _mm256_castpd_si256(v);
+    }
+    static bool all_false(opmask_t k){
+        return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
     }
 };
 

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -70,7 +70,7 @@ struct avx2_vector<int64_t> {
     } // TODO: this should broadcast bits as is?
     static opmask_t knot_opmask(opmask_t x)
     {
-        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF'FFFF'FFFF);
         return _mm256_xor_si256(x, allTrue);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
@@ -249,7 +249,7 @@ struct avx2_vector<uint64_t> {
     }
     static opmask_t knot_opmask(opmask_t x)
     {
-        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF'FFFF'FFFF);
         return _mm256_xor_si256(x, allTrue);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
@@ -439,7 +439,7 @@ struct avx2_vector<double> {
     }
     static opmask_t knot_opmask(opmask_t x)
     {
-        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF);
+        auto allTrue = _mm256_set1_epi64x(0xFFFF'FFFF'FFFF'FFFF);
         return _mm256_xor_si256(x, allTrue);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -81,6 +81,10 @@ struct zmm_vector<float16> {
                           exp_eq, mant_x, mant_y, _MM_CMPINT_NLT);
         return _kxor_mask32(mask_ge, neg);
     }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_epu16_mask(x, y);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         return ((0x1ull << num_to_read) - 0x1ull);
@@ -186,6 +190,9 @@ struct zmm_vector<float16> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return k == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -237,6 +244,10 @@ struct zmm_vector<int16_t> {
     static opmask_t ge(reg_t x, reg_t y)
     {
         return _mm512_cmp_epi16_mask(x, y, _MM_CMPINT_NLT);
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_epi16_mask(x, y);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -323,6 +334,9 @@ struct zmm_vector<int16_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return k == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -373,6 +387,10 @@ struct zmm_vector<uint16_t> {
     static opmask_t ge(reg_t x, reg_t y)
     {
         return _mm512_cmp_epu16_mask(x, y, _MM_CMPINT_NLT);
+    }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmpeq_epu16_mask(x, y);
     }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
@@ -456,6 +474,9 @@ struct zmm_vector<uint16_t> {
     static __m512i cast_to(reg_t v)
     {
         return v;
+    }
+    static bool all_false(opmask_t k){
+        return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -198,6 +198,9 @@ struct zmm_vector<int32_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return k == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -376,6 +379,9 @@ struct zmm_vector<uint32_t> {
     static __m512i cast_to(reg_t v)
     {
         return v;
+    }
+    static bool all_false(opmask_t k){
+        return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
@@ -569,6 +575,9 @@ struct zmm_vector<float> {
     static __m512i cast_to(reg_t v)
     {
         return _mm512_castps_si512(v);
+    }
+    static bool all_false(opmask_t k){
+        return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -732,6 +732,9 @@ struct zmm_vector<int64_t> {
     {
         return v;
     }
+    static bool all_false(opmask_t k){
+        return k == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,
@@ -902,6 +905,9 @@ struct zmm_vector<uint64_t> {
     static __m512i cast_to(reg_t v)
     {
         return v;
+    }
+    static bool all_false(opmask_t k){
+        return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
@@ -1092,6 +1098,9 @@ struct zmm_vector<double> {
     static __m512i cast_to(reg_t v)
     {
         return _mm512_castpd_si512(v);
+    }
+    static bool all_false(opmask_t k){
+        return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -55,6 +55,10 @@ struct zmm_vector<_Float16> {
     {
         return _mm512_cmp_ph_mask(x, y, _CMP_GE_OQ);
     }
+    static opmask_t eq(reg_t x, reg_t y)
+    {
+        return _mm512_cmp_ph_mask(x, y, _CMP_EQ_OQ);
+    }
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         return ((0x1ull << num_to_read) - 0x1ull);

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -150,6 +150,9 @@ struct zmm_vector<_Float16> {
     {
         return _mm512_castph_si512(v);
     }
+    static bool all_false(opmask_t k){
+        return k == 0;
+    }
     static int double_compressstore(type_t *left_addr,
                                     type_t *right_addr,
                                     opmask_t k,

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -106,4 +106,7 @@ struct avx2_half_vector;
 
 enum class simd_type : int { AVX2, AVX512 };
 
+template <typename vtype, typename T = typename vtype::type_t>
+X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
+
 #endif // XSS_COMMON_INCLUDES

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -502,7 +502,7 @@ qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
     auto pivot_result = get_pivot_smart<vtype, type_t>(arr, left, right);
     type_t pivot = pivot_result.pivot;
     
-    if (pivot_result.alreadySorted){
+    if (pivot_result.result == pivot_result_t::Sorted){
         return;
     }
     
@@ -513,7 +513,7 @@ qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
             = partition_avx512_unrolled<vtype, vtype::partition_unroll_factor>(
                     arr, left, right + 1, pivot, &smallest, &biggest);
     
-    if (pivot_result.only2Values){
+    if (pivot_result.result == pivot_result_t::Only2Values){
         return;
     }
 

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -498,14 +498,24 @@ qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
                 arr + left, (int32_t)(right + 1 - left));
         return;
     }
-
-    type_t pivot = get_pivot_blocks<vtype, type_t>(arr, left, right);
+    
+    auto pivot_result = get_pivot_smart<vtype, type_t>(arr, left, right);
+    type_t pivot = pivot_result.pivot;
+    
+    if (pivot_result.alreadySorted){
+        return;
+    }
+    
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
 
     arrsize_t pivot_index
             = partition_avx512_unrolled<vtype, vtype::partition_unroll_factor>(
                     arr, left, right + 1, pivot, &smallest, &biggest);
+    
+    if (pivot_result.only2Values){
+        return;
+    }
 
     if (pivot != smallest)
         qsort_<vtype>(arr, left, pivot_index - 1, max_iters - 1);

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -136,7 +136,7 @@ X86_SIMD_SORT_INLINE arrsize_t move_nans_to_end_of_array(T *arr, arrsize_t size)
     return size - count - 1;
 }
 
-template <typename vtype, typename T = typename vtype::type_t>
+template <typename vtype, typename T>
 X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b)
 {
     return a < b;

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -87,7 +87,8 @@ X86_SIMD_SORT_INLINE bool array_has_nan(type_t *arr, arrsize_t size)
         else {
             in = vtype::loadu(arr + ii);
         }
-        auto nanmask = vtype::convert_mask_to_int(vtype::template fpclass<0x01 | 0x80>(in));
+        auto nanmask = vtype::convert_mask_to_int(
+                vtype::template fpclass<0x01 | 0x80>(in));
         if (nanmask != 0x00) {
             found_nan = true;
             break;
@@ -498,24 +499,20 @@ qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
                 arr + left, (int32_t)(right + 1 - left));
         return;
     }
-    
+
     auto pivot_result = get_pivot_smart<vtype, type_t>(arr, left, right);
     type_t pivot = pivot_result.pivot;
-    
-    if (pivot_result.result == pivot_result_t::Sorted){
-        return;
-    }
-    
+
+    if (pivot_result.result == pivot_result_t::Sorted) { return; }
+
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
 
     arrsize_t pivot_index
             = partition_avx512_unrolled<vtype, vtype::partition_unroll_factor>(
                     arr, left, right + 1, pivot, &smallest, &biggest);
-    
-    if (pivot_result.result == pivot_result_t::Only2Values){
-        return;
-    }
+
+    if (pivot_result.result == pivot_result_t::Only2Values) { return; }
 
     if (pivot != smallest)
         qsort_<vtype>(arr, left, pivot_index - 1, max_iters - 1);

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -441,9 +441,8 @@ bitonic_fullmerge_n_vec(typename keyType::reg_t *keys,
 }
 
 template <typename keyType, typename indexType, int numVecs>
-X86_SIMD_SORT_INLINE void argsort_n_vec(typename keyType::type_t *keys,
-                                        arrsize_t *indices,
-                                        int N)
+X86_SIMD_SORT_INLINE void
+argsort_n_vec(typename keyType::type_t *keys, arrsize_t *indices, int N)
 {
     using kreg_t = typename keyType::reg_t;
     using ireg_t = typename indexType::reg_t;
@@ -586,9 +585,8 @@ X86_SIMD_SORT_INLINE void kvsort_n_vec(typename keyType::type_t *keys,
 }
 
 template <typename keyType, typename indexType, int maxN>
-X86_SIMD_SORT_INLINE void argsort_n(typename keyType::type_t *keys,
-                                    arrsize_t *indices,
-                                    int N)
+X86_SIMD_SORT_INLINE void
+argsort_n(typename keyType::type_t *keys, arrsize_t *indices, int N)
 {
     static_assert(keyType::numlanes == indexType::numlanes,
                   "invalid pairing of value/index types");

--- a/src/xss-network-qsort.hpp
+++ b/src/xss-network-qsort.hpp
@@ -4,6 +4,9 @@
 #include "xss-optimal-networks.hpp"
 #include "xss-common-qsort.h"
 
+template <typename vtype, typename mm_t>
+X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b);
+
 template <typename vtype, int numVecs, typename reg_t = typename vtype::reg_t>
 X86_SIMD_SORT_FINLINE void bitonic_sort_n_vec(reg_t *regs)
 {
@@ -141,6 +144,17 @@ X86_SIMD_SORT_FINLINE void merge_n_vec(reg_t *regs)
 }
 
 template <typename vtype, int numVecs, typename reg_t = typename vtype::reg_t>
+X86_SIMD_SORT_FINLINE void sort_vectors(reg_t * vecs){
+    /* Run the initial sorting network to sort the columns of the [numVecs x
+     * num_lanes] matrix
+     */
+    bitonic_sort_n_vec<vtype, numVecs>(vecs);
+
+    // Merge the vectors using bitonic merging networks
+    merge_n_vec<vtype, numVecs>(vecs);
+}
+
+template <typename vtype, int numVecs, typename reg_t = typename vtype::reg_t>
 X86_SIMD_SORT_INLINE void sort_n_vec(typename vtype::type_t *arr, int N)
 {
     static_assert(numVecs > 0, "numVecs should be > 0");
@@ -174,14 +188,8 @@ X86_SIMD_SORT_INLINE void sort_n_vec(typename vtype::type_t *arr, int N)
         vecs[i] = vtype::mask_loadu(
                 vtype::zmm_max(), ioMasks[j], arr + i * vtype::numlanes);
     }
-
-    /* Run the initial sorting network to sort the columns of the [numVecs x
-     * num_lanes] matrix
-     */
-    bitonic_sort_n_vec<vtype, numVecs>(vecs);
-
-    // Merge the vectors using bitonic merging networks
-    merge_n_vec<vtype, numVecs>(vecs);
+    
+    sort_vectors<vtype, numVecs>(vecs);
 
     // Unmasked part of the store
     X86_SIMD_SORT_UNROLL_LOOP(64)

--- a/src/xss-network-qsort.hpp
+++ b/src/xss-network-qsort.hpp
@@ -144,7 +144,8 @@ X86_SIMD_SORT_FINLINE void merge_n_vec(reg_t *regs)
 }
 
 template <typename vtype, int numVecs, typename reg_t = typename vtype::reg_t>
-X86_SIMD_SORT_FINLINE void sort_vectors(reg_t * vecs){
+X86_SIMD_SORT_FINLINE void sort_vectors(reg_t *vecs)
+{
     /* Run the initial sorting network to sort the columns of the [numVecs x
      * num_lanes] matrix
      */
@@ -188,7 +189,7 @@ X86_SIMD_SORT_INLINE void sort_n_vec(typename vtype::type_t *arr, int N)
         vecs[i] = vtype::mask_loadu(
                 vtype::zmm_max(), ioMasks[j], arr + i * vtype::numlanes);
     }
-    
+
     sort_vectors<vtype, numVecs>(vecs);
 
     // Unmasked part of the store

--- a/src/xss-optimal-networks.hpp
+++ b/src/xss-optimal-networks.hpp
@@ -1,6 +1,9 @@
 // All of these sources files are generated from the optimal networks described in
 // https://bertdobbelaere.github.io/sorting_networks.html
 
+template <typename vtype, typename mm_t>
+X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b);
+
 template <typename vtype, typename reg_t = typename vtype::reg_t>
 X86_SIMD_SORT_FINLINE void optimal_sort_4(reg_t *vecs)
 {

--- a/src/xss-pivot-selection.hpp
+++ b/src/xss-pivot-selection.hpp
@@ -1,5 +1,44 @@
+#ifndef XSS_PIVOT_SELECTION
+#define XSS_PIVOT_SELECTION
+
+#include "xss-network-qsort.hpp"
+
+template <typename type_t>
+struct pivot_results{
+    bool alreadySorted = false;
+    bool only2Values = false;
+    type_t pivot = 0;
+    
+    pivot_results(type_t _pivot){
+        pivot = _pivot;
+        alreadySorted = false;
+    }
+    
+    pivot_results(type_t _pivot, bool _alreadySorted){
+        pivot = _pivot;
+        alreadySorted = _alreadySorted;
+    }
+};
+
+template <typename type_t>
+type_t next_value(type_t value){
+    // TODO this probably handles non-native float16 wrong
+    if constexpr (std::is_floating_point<type_t>::value){
+        return std::nextafter(value, std::numeric_limits<type_t>::infinity());
+    }else{
+        if (value < std::numeric_limits<type_t>::max()){
+            return value + 1;
+        }else{
+            return value;
+        }
+    }
+}
+
 template <typename vtype, typename mm_t>
 X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b);
+
+template <typename vtype, typename T = typename vtype::type_t>
+X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
 
 template <typename vtype, typename type_t>
 X86_SIMD_SORT_INLINE type_t get_pivot(type_t *arr,
@@ -61,3 +100,141 @@ X86_SIMD_SORT_INLINE type_t get_pivot_blocks(type_t *arr,
     vtype::storeu(data, vec);
     return data[vtype::numlanes / 2];
 }
+
+template <typename vtype, typename type_t>
+X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
+                                             type_t commonValue,
+                                             const arrsize_t left,
+                                             const arrsize_t right);
+
+template <typename vtype, typename type_t>
+X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_smart(type_t *arr,
+                                             const arrsize_t left,
+                                             const arrsize_t right)
+{
+    using reg_t = typename vtype::reg_t;
+    constexpr int numVecs = 4;
+    
+    if (right - left + 1 <= 4 * numVecs * vtype::numlanes){
+        return pivot_results<type_t>(get_pivot<vtype>(arr, left, right)); 
+    }
+    
+    constexpr int N = numVecs * vtype::numlanes;
+
+    arrsize_t width = (right - vtype::numlanes) - left;
+    arrsize_t delta = width / numVecs;
+
+    reg_t vecs[numVecs];
+    for (int i = 0; i < numVecs; i++) {
+        vecs[i] = vtype::loadu(arr + left + delta * i);
+    }
+    
+    // Sort the samples
+    sort_vectors<vtype, numVecs>(vecs);
+    
+    type_t samples[N];
+    for (int i = 0; i < numVecs; i++){
+        vtype::storeu(samples + vtype::numlanes * i, vecs[i]);
+    }
+    
+    type_t smallest = samples[0];
+    type_t largest = samples[N - 1];
+    type_t median = samples[N / 2];
+    
+    if (smallest == largest){
+        // We have a very unlucky sample, or the array is constant / near constant
+        // Run a special function meant to deal with this situation
+        return get_pivot_near_constant<vtype, type_t>(arr, median, left, right);
+    }else if (median != smallest && median != largest){
+        // We have a normal sample; use it's median
+        return pivot_results<type_t>(median);
+    }else if (median == smallest){
+        // If median == smallest, that implies approximately half the array is equal to smallest, unless we were very unlucky with our sample
+        // Try just doing the next largest value greater than this seemingly very common value to seperate them out
+        return pivot_results<type_t>(next_value<type_t>(median));
+    }else if (median == largest){
+        // If median == largest, that implies approximately half the array is equal to largest, unless we were very unlucky with our sample
+        // Thus, median probably is a fine pivot, since it will move all of this common value into its own partition
+        return pivot_results<type_t>(median);
+    }else{
+        // Should be unreachable
+        return pivot_results<type_t>(median);
+    }
+    
+    // Should be unreachable
+    return pivot_results<type_t>(median);
+}
+
+// Handles the case where we seem to have a near-constant array, since our sample of the array was constant
+template <typename vtype, typename type_t>
+X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
+                                             type_t commonValue,
+                                             const arrsize_t left,
+                                             const arrsize_t right)
+{
+    using reg_t = typename vtype::reg_t;
+    
+    arrsize_t index = left;
+    
+    type_t value1 = 0;
+    type_t value2 = 0;
+    
+    // First, search for any value not equal to the common value
+    // First vectorized
+    reg_t commonVec = vtype::set1(commonValue);
+    for (; index <= right - vtype::numlanes; index += vtype::numlanes){
+        reg_t data = vtype::loadu(arr + index);
+        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec)))){
+            break;
+        }
+    }
+    
+    // Than scalar at the end
+    for (; index <= right; index++){
+        if (arr[index] != commonValue){
+            value1 = arr[index];
+            break;
+        } 
+    }
+    
+    if (index == right + 1){
+        // The array is completely constant
+        // Setting the second flag to true skips partitioning, as the array is constant and thus sorted
+        return pivot_results<type_t>(commonValue, true);
+    }
+    
+    // Secondly, search for a second value not equal to either of the previous two
+    // First vectorized
+    reg_t value1Vec = vtype::set1(value1);
+    for (; index <= right - vtype::numlanes; index += vtype::numlanes){
+        reg_t data = vtype::loadu(arr + index);
+        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec))) && !vtype::all_false(vtype::knot_opmask(vtype::eq(data, value1Vec)))){
+            break;
+        }
+    }
+    
+    // Then scalar
+    for (; index <= right; index++){
+        if (arr[index] != commonValue && arr[index] != value1){
+            value2 = arr[index];
+            break;
+        } 
+    }
+    
+    if (index == right + 1){
+        // The array contains only 2 values
+        // We must pick the larger one, else the right partition is empty
+        // We can also skip recursing, as it is guaranteed both partitions are constant after partitioning with the larger value
+        // TODO this logic now assumes we use greater than or equal to specifically when partitioning, might be worth noting that somewhere
+        type_t pivot = std::max(value1, commonValue, comparison_func<vtype>);
+        auto result = pivot_results<type_t>(pivot, false);
+        result.only2Values = true;
+        return result;
+    }
+    
+    // The array has at least 3 distinct values. Use the middle one as the pivot
+    type_t median = std::max(std::min(value1,value2, comparison_func<vtype>), std::min(std::max(value1,value2, comparison_func<vtype>),commonValue, comparison_func<vtype>), comparison_func<vtype>);
+    return pivot_results<type_t>(median);
+}
+
+#endif

--- a/src/xss-pivot-selection.hpp
+++ b/src/xss-pivot-selection.hpp
@@ -37,9 +37,6 @@ type_t next_value(type_t value){
 template <typename vtype, typename mm_t>
 X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b);
 
-template <typename vtype, typename T>
-X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
-
 template <typename vtype, typename type_t>
 X86_SIMD_SORT_INLINE type_t get_pivot(type_t *arr,
                                       const arrsize_t left,

--- a/src/xss-pivot-selection.hpp
+++ b/src/xss-pivot-selection.hpp
@@ -37,7 +37,7 @@ type_t next_value(type_t value){
 template <typename vtype, typename mm_t>
 X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b);
 
-template <typename vtype, typename T = typename vtype::type_t>
+template <typename vtype, typename T>
 X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
 
 template <typename vtype, typename type_t>

--- a/src/xss-pivot-selection.hpp
+++ b/src/xss-pivot-selection.hpp
@@ -6,26 +6,29 @@
 enum class pivot_result_t : int { Normal, Sorted, Only2Values };
 
 template <typename type_t>
-struct pivot_results{
-    
+struct pivot_results {
+
     pivot_result_t result = pivot_result_t::Normal;
     type_t pivot = 0;
-    
-    pivot_results(type_t _pivot, pivot_result_t _result = pivot_result_t::Normal){
+
+    pivot_results(type_t _pivot,
+                  pivot_result_t _result = pivot_result_t::Normal)
+    {
         pivot = _pivot;
         result = _result;
     }
 };
 
 template <typename type_t>
-type_t next_value(type_t value){
+type_t next_value(type_t value)
+{
     // TODO this probably handles non-native float16 wrong
-    if constexpr (std::is_floating_point<type_t>::value){
+    if constexpr (std::is_floating_point<type_t>::value) {
         return std::nextafter(value, std::numeric_limits<type_t>::infinity());
-    }else{
-        if (value < std::numeric_limits<type_t>::max()){
-            return value + 1;
-        }else{
+    }
+    else {
+        if (value < std::numeric_limits<type_t>::max()) { return value + 1; }
+        else {
             return value;
         }
     }
@@ -96,23 +99,23 @@ X86_SIMD_SORT_INLINE type_t get_pivot_blocks(type_t *arr,
 }
 
 template <typename vtype, typename type_t>
-X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
-                                             type_t commonValue,
-                                             const arrsize_t left,
-                                             const arrsize_t right);
+X86_SIMD_SORT_INLINE pivot_results<type_t>
+get_pivot_near_constant(type_t *arr,
+                        type_t commonValue,
+                        const arrsize_t left,
+                        const arrsize_t right);
 
 template <typename vtype, typename type_t>
-X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_smart(type_t *arr,
-                                             const arrsize_t left,
-                                             const arrsize_t right)
+X86_SIMD_SORT_INLINE pivot_results<type_t>
+get_pivot_smart(type_t *arr, const arrsize_t left, const arrsize_t right)
 {
     using reg_t = typename vtype::reg_t;
     constexpr int numVecs = 4;
-    
-    if (right - left + 1 <= 4 * numVecs * vtype::numlanes){
-        return pivot_results<type_t>(get_pivot<vtype>(arr, left, right)); 
+
+    if (right - left + 1 <= 4 * numVecs * vtype::numlanes) {
+        return pivot_results<type_t>(get_pivot<vtype>(arr, left, right));
     }
-    
+
     constexpr int N = numVecs * vtype::numlanes;
 
     arrsize_t width = (right - vtype::numlanes) - left;
@@ -122,100 +125,107 @@ X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_smart(type_t *arr,
     for (int i = 0; i < numVecs; i++) {
         vecs[i] = vtype::loadu(arr + left + delta * i);
     }
-    
+
     // Sort the samples
     sort_vectors<vtype, numVecs>(vecs);
-    
+
     type_t samples[N];
-    for (int i = 0; i < numVecs; i++){
+    for (int i = 0; i < numVecs; i++) {
         vtype::storeu(samples + vtype::numlanes * i, vecs[i]);
     }
-    
+
     type_t smallest = samples[0];
     type_t largest = samples[N - 1];
     type_t median = samples[N / 2];
-    
-    if (smallest == largest){
+
+    if (smallest == largest) {
         // We have a very unlucky sample, or the array is constant / near constant
         // Run a special function meant to deal with this situation
         return get_pivot_near_constant<vtype, type_t>(arr, median, left, right);
-    }else if (median != smallest && median != largest){
+    }
+    else if (median != smallest && median != largest) {
         // We have a normal sample; use it's median
         return pivot_results<type_t>(median);
-    }else if (median == smallest){
+    }
+    else if (median == smallest) {
         // If median == smallest, that implies approximately half the array is equal to smallest, unless we were very unlucky with our sample
         // Try just doing the next largest value greater than this seemingly very common value to seperate them out
         return pivot_results<type_t>(next_value<type_t>(median));
-    }else if (median == largest){
+    }
+    else if (median == largest) {
         // If median == largest, that implies approximately half the array is equal to largest, unless we were very unlucky with our sample
         // Thus, median probably is a fine pivot, since it will move all of this common value into its own partition
         return pivot_results<type_t>(median);
-    }else{
+    }
+    else {
         // Should be unreachable
         return pivot_results<type_t>(median);
     }
-    
+
     // Should be unreachable
     return pivot_results<type_t>(median);
 }
 
 // Handles the case where we seem to have a near-constant array, since our sample of the array was constant
 template <typename vtype, typename type_t>
-X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
-                                             type_t commonValue,
-                                             const arrsize_t left,
-                                             const arrsize_t right)
+X86_SIMD_SORT_INLINE pivot_results<type_t>
+get_pivot_near_constant(type_t *arr,
+                        type_t commonValue,
+                        const arrsize_t left,
+                        const arrsize_t right)
 {
     using reg_t = typename vtype::reg_t;
-    
+
     arrsize_t index = left;
-    
+
     type_t value1 = 0;
     type_t value2 = 0;
-    
+
     // First, search for any value not equal to the common value
     // First vectorized
     reg_t commonVec = vtype::set1(commonValue);
-    for (; index <= right - vtype::numlanes; index += vtype::numlanes){
+    for (; index <= right - vtype::numlanes; index += vtype::numlanes) {
         reg_t data = vtype::loadu(arr + index);
-        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec)))){
+        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec)))) {
             break;
         }
     }
-    
+
     // Than scalar at the end
-    for (; index <= right; index++){
-        if (arr[index] != commonValue){
+    for (; index <= right; index++) {
+        if (arr[index] != commonValue) {
             value1 = arr[index];
             break;
-        } 
+        }
     }
-    
-    if (index == right + 1){
+
+    if (index == right + 1) {
         // The array is completely constant
         // Setting the second flag to true skips partitioning, as the array is constant and thus sorted
         return pivot_results<type_t>(commonValue, pivot_result_t::Sorted);
     }
-    
+
     // Secondly, search for a second value not equal to either of the previous two
     // First vectorized
     reg_t value1Vec = vtype::set1(value1);
-    for (; index <= right - vtype::numlanes; index += vtype::numlanes){
+    for (; index <= right - vtype::numlanes; index += vtype::numlanes) {
         reg_t data = vtype::loadu(arr + index);
-        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec))) && !vtype::all_false(vtype::knot_opmask(vtype::eq(data, value1Vec)))){
+        if (!vtype::all_false(vtype::knot_opmask(vtype::eq(data, commonVec)))
+            && !vtype::all_false(
+                    vtype::knot_opmask(vtype::eq(data, value1Vec)))) {
             break;
         }
     }
-    
+
     // Then scalar
-    for (; index <= right; index++){
-        if (arr[index] != commonValue && arr[index] != value1){
+    for (; index <= right; index++) {
+        if (arr[index] != commonValue && arr[index] != value1) {
             value2 = arr[index];
             break;
-        } 
+        }
     }
-    
-    if (index == right + 1){
+
+    if (index == right + 1) {
         // The array contains only 2 values
         // We must pick the larger one, else the right partition is empty
         // We can also skip recursing, as it is guaranteed both partitions are constant after partitioning with the larger value
@@ -223,9 +233,14 @@ X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
         type_t pivot = std::max(value1, commonValue, comparison_func<vtype>);
         return pivot_results<type_t>(pivot, pivot_result_t::Only2Values);
     }
-    
+
     // The array has at least 3 distinct values. Use the middle one as the pivot
-    type_t median = std::max(std::min(value1,value2, comparison_func<vtype>), std::min(std::max(value1,value2, comparison_func<vtype>),commonValue, comparison_func<vtype>), comparison_func<vtype>);
+    type_t median = std::max(
+            std::min(value1, value2, comparison_func<vtype>),
+            std::min(std::max(value1, value2, comparison_func<vtype>),
+                     commonValue,
+                     comparison_func<vtype>),
+            comparison_func<vtype>);
     return pivot_results<type_t>(median);
 }
 

--- a/src/xss-pivot-selection.hpp
+++ b/src/xss-pivot-selection.hpp
@@ -3,20 +3,17 @@
 
 #include "xss-network-qsort.hpp"
 
+enum class pivot_result_t : int { Normal, Sorted, Only2Values };
+
 template <typename type_t>
 struct pivot_results{
-    bool alreadySorted = false;
-    bool only2Values = false;
+    
+    pivot_result_t result = pivot_result_t::Normal;
     type_t pivot = 0;
     
-    pivot_results(type_t _pivot){
+    pivot_results(type_t _pivot, pivot_result_t _result = pivot_result_t::Normal){
         pivot = _pivot;
-        alreadySorted = false;
-    }
-    
-    pivot_results(type_t _pivot, bool _alreadySorted){
-        pivot = _pivot;
-        alreadySorted = _alreadySorted;
+        result = _result;
     }
 };
 
@@ -197,7 +194,7 @@ X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
     if (index == right + 1){
         // The array is completely constant
         // Setting the second flag to true skips partitioning, as the array is constant and thus sorted
-        return pivot_results<type_t>(commonValue, true);
+        return pivot_results<type_t>(commonValue, pivot_result_t::Sorted);
     }
     
     // Secondly, search for a second value not equal to either of the previous two
@@ -224,9 +221,7 @@ X86_SIMD_SORT_INLINE pivot_results<type_t> get_pivot_near_constant(type_t *arr,
         // We can also skip recursing, as it is guaranteed both partitions are constant after partitioning with the larger value
         // TODO this logic now assumes we use greater than or equal to specifically when partitioning, might be worth noting that somewhere
         type_t pivot = std::max(value1, commonValue, comparison_func<vtype>);
-        auto result = pivot_results<type_t>(pivot, false);
-        result.only2Values = true;
-        return result;
+        return pivot_results<type_t>(pivot, pivot_result_t::Only2Values);
     }
     
     // The array has at least 3 distinct values. Use the middle one as the pivot

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -20,6 +20,7 @@ public:
                    "reverse",
                    "smallrange",
                    "max_at_the_end",
+                   "random_5d",
                    "rand_max"};
     }
     std::vector<std::string> arrtype;

--- a/tests/test-objqsort.cpp
+++ b/tests/test-objqsort.cpp
@@ -32,6 +32,7 @@ public:
                    "reverse",
                    "smallrange",
                    "max_at_the_end",
+                   "random_5d",
                    "rand_max"};
     }
     std::vector<std::string> arrtype;

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -17,6 +17,7 @@ public:
                    "reverse",
                    "smallrange",
                    "max_at_the_end",
+                   "random_5d",
                    "rand_max",
                    "rand_with_nan"};
     }


### PR DESCRIPTION
This changes the pivot selection algorithm to give better results when handling special cases, with only a minimal impact on random sorting performance

5d benchmarks (50% random data, 50% 0)
```
---------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_5d vs. simdsort/random_5d]/uint64_t                -0.8243         -0.8242        151220         26569        151234         26580
[simdsort/random_5d vs. simdsort/random_5d]/int64_t                 -0.9165         -0.9165        334204         27897        334232         27903
[simdsort/random_5d vs. simdsort/random_5d]/uint32_t                -0.8788         -0.8788        135372         16402        135385         16406
[simdsort/random_5d vs. simdsort/random_5d]/int32_t                 -0.9400         -0.9399        290022         17393        290049         17434
[simdsort/random_5d vs. simdsort/random_5d]/uint16_t                -0.0001         -0.0001        294730        294693        294728        294691
[simdsort/random_5d vs. simdsort/random_5d]/int16_t                 +0.0007         +0.0007        298364        298574        298366        298576
[simdsort/random_5d vs. simdsort/random_5d]/float                   -0.9187         -0.9187        213828         17389        213879         17395
[simdsort/random_5d vs. simdsort/random_5d]/double                  -0.8617         -0.8616        164907         22804        164909         22823
OVERALL_GEOMEAN                                                     -0.8181         -0.8180             0             0             0             0
```

The effect is even more dramatic with 5p (95% 0, 5% random data)
```
Benchmark                                                              Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_5p vs. simdsort/random_5p]/uint64_t                -0.9764         -0.9764        291537          6867        291545          6870
[simdsort/random_5p vs. simdsort/random_5p]/int64_t                 -0.9494         -0.9494        276980         14006        277013         14020
[simdsort/random_5p vs. simdsort/random_5p]/uint32_t                -0.9864         -0.9864        266197          3628        266206          3633
[simdsort/random_5p vs. simdsort/random_5p]/int32_t                 -0.9608         -0.9609        226929          8887        226950          8885
[simdsort/random_5p vs. simdsort/random_5p]/uint16_t                -0.0002         -0.0002         98157         98139         98159         98136
[simdsort/random_5p vs. simdsort/random_5p]/int16_t                 +0.0147         +0.0145        101119        102601        101137        102608
[simdsort/random_5p vs. simdsort/random_5p]/float                   -0.9890         -0.9890        334314          3677        334329          3686
[simdsort/random_5p vs. simdsort/random_5p]/double                  -0.9794         -0.9794        280964          5792        280992          5789
OVERALL_GEOMEAN                                                     -0.9410         -0.9410             0             0             0             0
```

And it has only minimal effect on random sorts
```
Benchmark                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_1 vs. simdsort/random_1]28/uint64_t                 +0.0013         +0.0002          1064          1065          1066          1066
[simdsort/random_1 vs. simdsort/random_1]k/uint64_t                  -0.0828         -0.0789          4888          4483          4893          4507
[simdsort/random_1 vs. simdsort/random_1]0k/uint64_t                 +0.0284         +0.0288         48691         50075         48699         50101
[simdsort/random_1 vs. simdsort/random_1]00k/uint64_t                +0.0124         +0.0125        614858        622497        614800        622495
[simdsort/random_1 vs. simdsort/random_1]m/uint64_t                  -0.0016         -0.0016       7963406       7950498       7962454       7949389
[simdsort/random_1 vs. simdsort/random_1]0m/uint64_t                 +0.0016         +0.0015     102066488     102229047     102059570     102211370
[simdsort/random_1 vs. simdsort/random_1]00m/uint64_t                -0.0043         -0.0043    1261115514    1255706439    1260972344    1255555986
[simdsort/random_1 vs. simdsort/random_1]28/int64_t                  -0.0031         -0.0024          1079          1076          1080          1077
[simdsort/random_1 vs. simdsort/random_1]k/int64_t                   -0.0853         -0.0858          4898          4480          4906          4485
[simdsort/random_1 vs. simdsort/random_1]0k/int64_t                  +0.0193         +0.0193         48866         49809         48873         49815
[simdsort/random_1 vs. simdsort/random_1]00k/int64_t                 +0.0060         +0.0060        618016        621698        617904        621614
[simdsort/random_1 vs. simdsort/random_1]m/int64_t                   -0.0056         -0.0056       7975085       7930691       7973995       7929683
[simdsort/random_1 vs. simdsort/random_1]0m/int64_t                  -0.0049         -0.0049     102474572     101974270     102465490     101962091
[simdsort/random_1 vs. simdsort/random_1]00m/int64_t                 -0.0066         -0.0065    1263240116    1254923614    1263009455    1254839009
[simdsort/random_1 vs. simdsort/random_1]28/uint32_t                 +0.0051         +0.0053           935           940           937           942
[simdsort/random_1 vs. simdsort/random_1]k/uint32_t                  -0.1471         -0.1437          3347          2855          3353          2871
[simdsort/random_1 vs. simdsort/random_1]0k/uint32_t                 -0.0222         -0.0221         28865         28225         28874         28235
[simdsort/random_1 vs. simdsort/random_1]00k/uint32_t                +0.0054         +0.0053        324099        325843        324105        325827
[simdsort/random_1 vs. simdsort/random_1]m/uint32_t                  +0.0046         +0.0045       4117560       4136371       4117024       4135636
[simdsort/random_1 vs. simdsort/random_1]0m/uint32_t                 +0.0114         +0.0114      51561459      52150283      51556319      52141569
[simdsort/random_1 vs. simdsort/random_1]00m/uint32_t                +0.0082         +0.0082     632611014     637805043     632526787     637722054
[simdsort/random_1 vs. simdsort/random_1]28/int32_t                  +0.0009         +0.0007           936           937           938           939
[simdsort/random_1 vs. simdsort/random_1]k/int32_t                   -0.1457         -0.1450          3353          2865          3363          2875
[simdsort/random_1 vs. simdsort/random_1]0k/int32_t                  -0.0203         -0.0203         28924         28337         28934         28345
[simdsort/random_1 vs. simdsort/random_1]00k/int32_t                 +0.0133         +0.0133        325551        329877        325534        329863
[simdsort/random_1 vs. simdsort/random_1]m/int32_t                   +0.0097         +0.0096       4115448       4155258       4114830       4154388
[simdsort/random_1 vs. simdsort/random_1]0m/int32_t                  +0.0142         +0.0142      51585804      52320726      51583209      52313573
[simdsort/random_1 vs. simdsort/random_1]00m/int32_t                 +0.0084         +0.0085     631352251     636675270     631267985     636612649
[simdsort/random_1 vs. simdsort/random_1]28/uint16_t                 -0.0003         -0.0003          1492          1491          1494          1493
[simdsort/random_1 vs. simdsort/random_1]k/uint16_t                  -0.0090         -0.0091         18904         18734         18922         18750
[simdsort/random_1 vs. simdsort/random_1]0k/uint16_t                 +0.0030         +0.0030        468432        469831        468403        469828
[simdsort/random_1 vs. simdsort/random_1]00k/uint16_t                -0.0012         -0.0013       5744202       5737147       5743967       5736718
[simdsort/random_1 vs. simdsort/random_1]m/uint16_t                  -0.0017         -0.0017      61193873      61090475      61190918      61084877
[simdsort/random_1 vs. simdsort/random_1]0m/uint16_t                 -0.0016         -0.0015     600309938     599348331     600224176     599306133
[simdsort/random_1 vs. simdsort/random_1]00m/uint16_t                -0.0032         -0.0032    6191154992    6171530176    6190615025    6170971515
[simdsort/random_1 vs. simdsort/random_1]28/int16_t                  -0.0003         -0.0006          1437          1436          1439          1438
[simdsort/random_1 vs. simdsort/random_1]k/int16_t                   -0.0097         -0.0098         19681         19491         19704         19512
[simdsort/random_1 vs. simdsort/random_1]0k/int16_t                  -0.0006         -0.0005        466306        466035        466273        466033
[simdsort/random_1 vs. simdsort/random_1]00k/int16_t                 -0.0001         -0.0002       5723278       5722493       5723190       5722214
[simdsort/random_1 vs. simdsort/random_1]m/int16_t                   +0.0005         +0.0005      61277756      61308199      61274535      61304592
[simdsort/random_1 vs. simdsort/random_1]0m/int16_t                  +0.0014         +0.0014     600496331     601344388     600441525     601300594
[simdsort/random_1 vs. simdsort/random_1]00m/int16_t                 -0.0009         -0.0009    6194612836    6188971652    6194055312    6188366358
[simdsort/random_1 vs. simdsort/random_1]28/float                    -0.0001         +0.0001           942           942           944           944
[simdsort/random_1 vs. simdsort/random_1]k/float                     -0.1467         -0.1458          3351          2859          3359          2869
[simdsort/random_1 vs. simdsort/random_1]0k/float                    +0.0507         +0.0506         27523         28918         27534         28928
[simdsort/random_1 vs. simdsort/random_1]00k/float                   +0.0261         +0.0261        326930        335451        326925        335464
[simdsort/random_1 vs. simdsort/random_1]m/float                     +0.0231         +0.0230       4147265       4243189       4146860       4242178
[simdsort/random_1 vs. simdsort/random_1]0m/float                    +0.0122         +0.0122      51795113      52426061      51788024      52419588
[simdsort/random_1 vs. simdsort/random_1]00m/float                   +0.0092         +0.0093     635098275     640935123     635037557     640923078
[simdsort/random_1 vs. simdsort/random_1]28/double                   +0.0070         +0.0067           987           993           989           995
[simdsort/random_1 vs. simdsort/random_1]k/double                    +0.0640         +0.0652          3938          4190          3943          4200
[simdsort/random_1 vs. simdsort/random_1]0k/double                   +0.0059         +0.0062         40154         40389         40163         40414
[simdsort/random_1 vs. simdsort/random_1]00k/double                  -0.0159         -0.0159        522386        514063        522326        514025
[simdsort/random_1 vs. simdsort/random_1]m/double                    -0.0139         -0.0138       7014815       6917393       7013658       6916682
[simdsort/random_1 vs. simdsort/random_1]0m/double                   -0.0054         -0.0054      92820075      92320669      92805992      92308498
[simdsort/random_1 vs. simdsort/random_1]00m/double                  -0.0094         -0.0094    1163669840    1152740315    1163500804    1152540374
OVERALL_GEOMEAN                                                      -0.0079         -0.0077             0             0             0             0
```