### PR TITLE
Clang-formatting fixes for Green CI

### DIFF
--- a/src/avx2-32bit-qsort.hpp
+++ b/src/avx2-32bit-qsort.hpp
@@ -209,7 +209,8 @@ struct avx2_vector<int32_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -362,7 +363,8 @@ struct avx2_vector<uint32_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -532,7 +534,8 @@ struct avx2_vector<float> {
     {
         return _mm256_castps_si256(v);
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_ps(_mm256_castsi256_ps(k)) == 0;
     }
     static int double_compressstore(type_t *left_addr,

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -214,7 +214,8 @@ struct avx2_vector<int64_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
     }
 };
@@ -391,7 +392,8 @@ struct avx2_vector<uint64_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
     }
 };
@@ -590,7 +592,8 @@ struct avx2_vector<double> {
     {
         return _mm256_castpd_si256(v);
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return _mm256_movemask_pd(_mm256_castsi256_pd(k)) == 0;
     }
 };

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -190,7 +190,8 @@ struct zmm_vector<float16> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -334,7 +335,8 @@ struct zmm_vector<int16_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -475,7 +477,8 @@ struct zmm_vector<uint16_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,

--- a/src/avx512-32bit-qsort.hpp
+++ b/src/avx512-32bit-qsort.hpp
@@ -198,7 +198,8 @@ struct zmm_vector<int32_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -380,7 +381,8 @@ struct zmm_vector<uint32_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -576,7 +578,8 @@ struct zmm_vector<float> {
     {
         return _mm512_castps_si512(v);
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -732,7 +732,8 @@ struct zmm_vector<int64_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -906,7 +907,8 @@ struct zmm_vector<uint64_t> {
     {
         return v;
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,
@@ -1099,7 +1101,8 @@ struct zmm_vector<double> {
     {
         return _mm512_castpd_si512(v);
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -154,7 +154,8 @@ struct zmm_vector<_Float16> {
     {
         return _mm512_castph_si512(v);
     }
-    static bool all_false(opmask_t k){
+    static bool all_false(opmask_t k)
+    {
         return k == 0;
     }
     static int double_compressstore(type_t *left_addr,


### PR DESCRIPTION
This will correct new clang-formatting issues in the repository, allowing for CI to become green.