### PR TITLE
[fix] key cron-based github actions to run only on intel/x86-simd-sort repo

### DIFF
--- a/.github/workflows/build-numpy.yml
+++ b/.github/workflows/build-numpy.yml
@@ -13,6 +13,7 @@ permissions: read-all
 jobs:
   np-multiarray-tgl:
 
+    if: github.repository == 'intel/x86-simd-sort'
     runs-on: intel-ubuntu-latest
 
     steps:
@@ -78,6 +79,7 @@ jobs:
 
   np-multiarray-spr:
 
+    if: github.repository == 'intel/x86-simd-sort'
     runs-on: intel-ubuntu-latest
 
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'intel/x86-simd-sort'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,7 @@ permissions: read-all
 
 jobs:
   analysis:
+  
     name: Scorecard analysis
     if: github.repository == 'intel/x86-simd-sort'
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've been getting erroneous emails with cron-based github actions failing based off this repo. It seems that my fork is running the github actions as well. This can be stopped by adding an if statement to the cron-based github actions based on the github repository.  These actions with the if statement will only work on intel/x86-simd-sort.

I don't know if this was a desired behavior, and maintainers can change the PR as they wish. This is only a suggestion.

Note, this will be useful for people who fork this repo in the future, or update their fork's main branch.