### PR TITLE
Fix bug while processing NAN in key-value sort

### DIFF
--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -57,13 +57,13 @@ template <typename vtype1,
           typename type_t2 = typename vtype2::type_t,
           typename reg_t1 = typename vtype1::reg_t,
           typename reg_t2 = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE arrsize_t kvpartition_avx512(type_t1 *keys,
-                                                  type_t2 *indexes,
-                                                  arrsize_t left,
-                                                  arrsize_t right,
-                                                  type_t1 pivot,
-                                                  type_t1 *smallest,
-                                                  type_t1 *biggest)
+X86_SIMD_SORT_INLINE arrsize_t kvpartition(type_t1 *keys,
+                                           type_t2 *indexes,
+                                           arrsize_t left,
+                                           arrsize_t right,
+                                           type_t1 pivot,
+                                           type_t1 *smallest,
+                                           type_t1 *biggest)
 {
     /* make array length divisible by vtype1::numlanes , shortening the array */
     for (int32_t i = (right - left) % vtype1::numlanes; i > 0; --i) {
@@ -189,16 +189,16 @@ template <typename vtype1,
           typename type_t2 = typename vtype2::type_t,
           typename reg_t1 = typename vtype1::reg_t,
           typename reg_t2 = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE arrsize_t kvpartition_avx512_unrolled(type_t1 *keys,
-                                                           type_t2 *indexes,
-                                                           arrsize_t left,
-                                                           arrsize_t right,
-                                                           type_t1 pivot,
-                                                           type_t1 *smallest,
-                                                           type_t1 *biggest)
+X86_SIMD_SORT_INLINE arrsize_t kvpartition_unrolled(type_t1 *keys,
+                                                    type_t2 *indexes,
+                                                    arrsize_t left,
+                                                    arrsize_t right,
+                                                    type_t1 pivot,
+                                                    type_t1 *smallest,
+                                                    type_t1 *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype1::numlanes) {
-        return kvpartition_avx512<vtype1, vtype2>(
+        return kvpartition<vtype1, vtype2>(
                 keys, indexes, left, right, pivot, smallest, biggest);
     }
     /* make array length divisible by vtype1::numlanes , shortening the array */
@@ -391,7 +391,7 @@ X86_SIMD_SORT_INLINE void qsort_64bit_(type1_t *keys,
     type1_t pivot = get_pivot_blocks<vtype1>(keys, left, right);
     type1_t smallest = vtype1::type_max();
     type1_t biggest = vtype1::type_min();
-    arrsize_t pivot_index = kvpartition_avx512_unrolled<vtype1, vtype2, 4>(
+    arrsize_t pivot_index = kvpartition_unrolled<vtype1, vtype2, 4>(
             keys, indexes, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest) {
         qsort_64bit_<vtype1, vtype2>(

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -422,8 +422,7 @@ avx512_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
         if constexpr (std::is_floating_point_v<T1>) {
             arrsize_t nan_count = 0;
             if (UNLIKELY(hasnan)) {
-                nan_count = replace_nan_with_inf<zmm_vector<double>>(keys,
-                                                                     arrsize);
+                nan_count = replace_nan_with_inf<zmm_vector<T1>>(keys, arrsize);
             }
             qsort_64bit_<keytype, valtype>(keys,
                                            indexes,

--- a/src/avx512-64bit-keyvaluesort.hpp
+++ b/src/avx512-64bit-keyvaluesort.hpp
@@ -57,13 +57,13 @@ template <typename vtype1,
           typename type_t2 = typename vtype2::type_t,
           typename reg_t1 = typename vtype1::reg_t,
           typename reg_t2 = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE arrsize_t partition_avx512(type_t1 *keys,
-                                                type_t2 *indexes,
-                                                arrsize_t left,
-                                                arrsize_t right,
-                                                type_t1 pivot,
-                                                type_t1 *smallest,
-                                                type_t1 *biggest)
+X86_SIMD_SORT_INLINE arrsize_t kvpartition_avx512(type_t1 *keys,
+                                                  type_t2 *indexes,
+                                                  arrsize_t left,
+                                                  arrsize_t right,
+                                                  type_t1 pivot,
+                                                  type_t1 *smallest,
+                                                  type_t1 *biggest)
 {
     /* make array length divisible by vtype1::numlanes , shortening the array */
     for (int32_t i = (right - left) % vtype1::numlanes; i > 0; --i) {
@@ -189,16 +189,16 @@ template <typename vtype1,
           typename type_t2 = typename vtype2::type_t,
           typename reg_t1 = typename vtype1::reg_t,
           typename reg_t2 = typename vtype2::reg_t>
-X86_SIMD_SORT_INLINE arrsize_t partition_avx512_unrolled(type_t1 *keys,
-                                                         type_t2 *indexes,
-                                                         arrsize_t left,
-                                                         arrsize_t right,
-                                                         type_t1 pivot,
-                                                         type_t1 *smallest,
-                                                         type_t1 *biggest)
+X86_SIMD_SORT_INLINE arrsize_t kvpartition_avx512_unrolled(type_t1 *keys,
+                                                           type_t2 *indexes,
+                                                           arrsize_t left,
+                                                           arrsize_t right,
+                                                           type_t1 pivot,
+                                                           type_t1 *smallest,
+                                                           type_t1 *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype1::numlanes) {
-        return partition_avx512<vtype1, vtype2>(
+        return kvpartition_avx512<vtype1, vtype2>(
                 keys, indexes, left, right, pivot, smallest, biggest);
     }
     /* make array length divisible by vtype1::numlanes , shortening the array */
@@ -391,7 +391,7 @@ X86_SIMD_SORT_INLINE void qsort_64bit_(type1_t *keys,
     type1_t pivot = get_pivot_blocks<vtype1>(keys, left, right);
     type1_t smallest = vtype1::type_max();
     type1_t biggest = vtype1::type_min();
-    arrsize_t pivot_index = partition_avx512_unrolled<vtype1, vtype2, 4>(
+    arrsize_t pivot_index = kvpartition_avx512_unrolled<vtype1, vtype2, 4>(
             keys, indexes, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest) {
         qsort_64bit_<vtype1, vtype2>(

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -173,13 +173,13 @@ X86_SIMD_SORT_INLINE int32_t partition_vec(type_t *arg,
  * last element that is less than equal to the pivot.
  */
 template <typename vtype, typename argtype, typename type_t>
-X86_SIMD_SORT_INLINE arrsize_t partition_avx512(type_t *arr,
-                                                arrsize_t *arg,
-                                                arrsize_t left,
-                                                arrsize_t right,
-                                                type_t pivot,
-                                                type_t *smallest,
-                                                type_t *biggest)
+X86_SIMD_SORT_INLINE arrsize_t argpartition_avx512(type_t *arr,
+                                                   arrsize_t *arg,
+                                                   arrsize_t left,
+                                                   arrsize_t right,
+                                                   type_t pivot,
+                                                   type_t *smallest,
+                                                   type_t *biggest)
 {
     /* make array length divisible by vtype::numlanes , shortening the array */
     for (int32_t i = (right - left) % vtype::numlanes; i > 0; --i) {
@@ -292,16 +292,16 @@ template <typename vtype,
           typename argtype,
           int num_unroll,
           typename type_t = typename vtype::type_t>
-X86_SIMD_SORT_INLINE arrsize_t partition_avx512_unrolled(type_t *arr,
-                                                         arrsize_t *arg,
-                                                         arrsize_t left,
-                                                         arrsize_t right,
-                                                         type_t pivot,
-                                                         type_t *smallest,
-                                                         type_t *biggest)
+X86_SIMD_SORT_INLINE arrsize_t argpartition_avx512_unrolled(type_t *arr,
+                                                            arrsize_t *arg,
+                                                            arrsize_t left,
+                                                            arrsize_t right,
+                                                            type_t pivot,
+                                                            type_t *smallest,
+                                                            type_t *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype::numlanes) {
-        return partition_avx512<vtype, argtype>(
+        return argpartition_avx512<vtype, argtype>(
                 arr, arg, left, right, pivot, smallest, biggest);
     }
     /* make array length divisible by vtype::numlanes , shortening the array */
@@ -493,7 +493,7 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
     type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_avx512_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         argsort_64bit_<vtype, argtype>(
@@ -529,7 +529,7 @@ X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
     type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = partition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_avx512_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         argselect_64bit_<vtype, argtype>(

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -173,13 +173,13 @@ X86_SIMD_SORT_INLINE int32_t partition_vec(type_t *arg,
  * last element that is less than equal to the pivot.
  */
 template <typename vtype, typename argtype, typename type_t>
-X86_SIMD_SORT_INLINE arrsize_t argpartition_avx512(type_t *arr,
-                                                   arrsize_t *arg,
-                                                   arrsize_t left,
-                                                   arrsize_t right,
-                                                   type_t pivot,
-                                                   type_t *smallest,
-                                                   type_t *biggest)
+X86_SIMD_SORT_INLINE arrsize_t argpartition(type_t *arr,
+                                            arrsize_t *arg,
+                                            arrsize_t left,
+                                            arrsize_t right,
+                                            type_t pivot,
+                                            type_t *smallest,
+                                            type_t *biggest)
 {
     /* make array length divisible by vtype::numlanes , shortening the array */
     for (int32_t i = (right - left) % vtype::numlanes; i > 0; --i) {
@@ -292,16 +292,16 @@ template <typename vtype,
           typename argtype,
           int num_unroll,
           typename type_t = typename vtype::type_t>
-X86_SIMD_SORT_INLINE arrsize_t argpartition_avx512_unrolled(type_t *arr,
-                                                            arrsize_t *arg,
-                                                            arrsize_t left,
-                                                            arrsize_t right,
-                                                            type_t pivot,
-                                                            type_t *smallest,
-                                                            type_t *biggest)
+X86_SIMD_SORT_INLINE arrsize_t argpartition_unrolled(type_t *arr,
+                                                     arrsize_t *arg,
+                                                     arrsize_t left,
+                                                     arrsize_t right,
+                                                     type_t pivot,
+                                                     type_t *smallest,
+                                                     type_t *biggest)
 {
     if (right - left <= 8 * num_unroll * vtype::numlanes) {
-        return argpartition_avx512<vtype, argtype>(
+        return argpartition<vtype, argtype>(
                 arr, arg, left, right, pivot, smallest, biggest);
     }
     /* make array length divisible by vtype::numlanes , shortening the array */
@@ -493,7 +493,7 @@ X86_SIMD_SORT_INLINE void argsort_64bit_(type_t *arr,
     type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = argpartition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if (pivot != smallest)
         argsort_64bit_<vtype, argtype>(
@@ -529,7 +529,7 @@ X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
     type_t pivot = get_pivot_64bit<vtype>(arr, arg, left, right);
     type_t smallest = vtype::type_max();
     type_t biggest = vtype::type_min();
-    arrsize_t pivot_index = argpartition_avx512_unrolled<vtype, argtype, 4>(
+    arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
     if ((pivot != smallest) && (pos < pivot_index))
         argselect_64bit_<vtype, argtype>(


### PR DESCRIPTION
Our key-value tests don't cover NAN's and looks like a bug snuck through. 