### PR TITLE
Adds descending order sort to argsort

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ how fast this is relative to `std::sort`.
 
 ## Sort an array of built-in integers and floats
 ```cpp
-void x86simdsort::qsort(T* arr, size_t size, bool hasnan);
-void x86simdsort::qselect(T* arr, size_t k, size_t size, bool hasnan);
-void x86simdsort::partial_qsort(T* arr, size_t k, size_t size, bool hasnan);
+void x86simdsort::qsort(T* arr, size_t size, bool hasnan, bool descending);
+void x86simdsort::qselect(T* arr, size_t k, size_t size, bool hasnan, bool descending);
+void x86simdsort::partial_qsort(T* arr, size_t k, size_t size, bool hasnan, bool descending);
 ```
 Supported datatypes: `T` $\in$ `[_Float16, uint16_t, int16_t, float, uint32_t,
 int32_t, double, uint64_t, int64_t]`
@@ -53,7 +53,7 @@ data types.
 
 ## Arg sort routines on arrays
 ```cpp
-std::vector<size_t> arg = x86simdsort::argsort(T* arr, size_t size, bool hasnan);
+std::vector<size_t> arg = x86simdsort::argsort(T* arr, size_t size, bool hasnan, bool descending);
 std::vector<size_t> arg = x86simdsort::argselect(T* arr, size_t k, size_t size, bool hasnan);
 ```
 Supported datatypes: `T` $\in$ `[_Float16, uint16_t, int16_t, float, uint32_t,

--- a/benchmarks/bench-argsort.hpp
+++ b/benchmarks/bench-argsort.hpp
@@ -46,6 +46,22 @@ static void simdargsort(benchmark::State &state, Args &&...args)
 }
 
 template <typename T, class... Args>
+static void simd_revargsort(benchmark::State &state, Args &&...args)
+{
+    // get args
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    size_t arrsize = std::get<0>(args_tuple);
+    std::string arrtype = std::get<1>(args_tuple);
+    // set up array
+    std::vector<T> arr = get_array<T>(arrtype, arrsize);
+    std::vector<size_t> inx;
+    // benchmark
+    for (auto _ : state) {
+        inx = x86simdsort::argsort(arr.data(), arrsize, false, true);
+    }
+}
+
+template <typename T, class... Args>
 static void simd_ordern_argsort(benchmark::State &state, Args &&...args)
 {
     // get args
@@ -68,6 +84,7 @@ static void simd_ordern_argsort(benchmark::State &state, Args &&...args)
 
 #define BENCH_BOTH(type) \
     BENCH_SORT(simdargsort, type) \
+    BENCH_SORT(simd_revargsort, type) \
     BENCH_SORT(simd_ordern_argsort, type) \
     BENCH_SORT(scalarargsort, type)
 

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -24,7 +24,8 @@
         avx2_partial_qsort(arr, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan, bool descending) \
+    std::vector<size_t> argsort( \
+            type *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
         return avx2_argsort(arr, arrsize, hasnan, descending); \
     } \

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -24,9 +24,9 @@
         avx2_partial_qsort(arr, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan) \
+    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
-        return avx2_argsort(arr, arrsize, hasnan); \
+        return avx2_argsort(arr, arrsize, hasnan, descending); \
     } \
     template <> \
     std::vector<size_t> argselect( \

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -30,8 +30,10 @@ namespace avx512 {
                                        bool descending = false);
     // argsort
     template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
+                                                size_t arrsize,
+                                                bool hasnan = false,
+                                                bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
@@ -62,8 +64,10 @@ namespace avx2 {
                                        bool descending = false);
     // argsort
     template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
+                                                size_t arrsize,
+                                                bool hasnan = false,
+                                                bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
@@ -94,8 +98,10 @@ namespace scalar {
                                        bool descending = false);
     // argsort
     template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
+                                                size_t arrsize,
+                                                bool hasnan = false,
+                                                bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -31,7 +31,7 @@ namespace avx512 {
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false);
+    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
@@ -63,7 +63,7 @@ namespace avx2 {
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false);
+    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
@@ -95,7 +95,7 @@ namespace scalar {
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>
-    argsort(T *arr, size_t arrsize, bool hasnan = false);
+    argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // argselect
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t>

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -70,15 +70,20 @@ namespace scalar {
                           xss::utils::get_cmp_func<T>(hasnan, reversed));
     }
     template <typename T>
-    std::vector<size_t> argsort(T *arr, size_t arrsize, bool hasnan, bool reversed)
+    std::vector<size_t>
+    argsort(T *arr, size_t arrsize, bool hasnan, bool reversed)
     {
         UNUSED(hasnan);
         std::vector<size_t> arg(arrsize);
         std::iota(arg.begin(), arg.end(), 0);
-        if (reversed){
-            std::sort(arg.begin(), arg.end(), compare_arg<T, std::greater<T>>(arr));
-        }else{
-            std::sort(arg.begin(), arg.end(), compare_arg<T, std::less<T>>(arr));
+        if (reversed) {
+            std::sort(arg.begin(),
+                      arg.end(),
+                      compare_arg<T, std::greater<T>>(arr));
+        }
+        else {
+            std::sort(
+                    arg.begin(), arg.end(), compare_arg<T, std::less<T>>(arr));
         }
         return arg;
     }

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -70,12 +70,16 @@ namespace scalar {
                           xss::utils::get_cmp_func<T>(hasnan, reversed));
     }
     template <typename T>
-    std::vector<size_t> argsort(T *arr, size_t arrsize, bool hasnan)
+    std::vector<size_t> argsort(T *arr, size_t arrsize, bool hasnan, bool reversed)
     {
         UNUSED(hasnan);
         std::vector<size_t> arg(arrsize);
         std::iota(arg.begin(), arg.end(), 0);
-        std::sort(arg.begin(), arg.end(), compare_arg<T, std::less<T>>(arr));
+        if (reversed){
+            std::sort(arg.begin(), arg.end(), compare_arg<T, std::greater<T>>(arr));
+        }else{
+            std::sort(arg.begin(), arg.end(), compare_arg<T, std::less<T>>(arr));
+        }
         return arg;
     }
     template <typename T>
@@ -93,7 +97,7 @@ namespace scalar {
     template <typename T1, typename T2>
     void keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan)
     {
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan);
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -24,9 +24,9 @@
         avx512_partial_qsort(arr, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan) \
+    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
-        return avx512_argsort(arr, arrsize, hasnan); \
+        return avx512_argsort(arr, arrsize, hasnan, descending); \
     } \
     template <> \
     std::vector<size_t> argselect( \

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -24,7 +24,8 @@
         avx512_partial_qsort(arr, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    std::vector<size_t> argsort(type *arr, size_t arrsize, bool hasnan, bool descending) \
+    std::vector<size_t> argsort( \
+            type *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
         return avx512_argsort(arr, arrsize, hasnan, descending); \
     } \

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -86,10 +86,12 @@ namespace x86simdsort {
     }
 
 #define DECLARE_INTERNAL_argsort(TYPE) \
-    static std::vector<size_t> (*internal_argsort##TYPE)(TYPE *, size_t, bool, bool) \
+    static std::vector<size_t> (*internal_argsort##TYPE)( \
+            TYPE *, size_t, bool, bool) \
             = NULL; \
     template <> \
-    std::vector<size_t> argsort(TYPE *arr, size_t arrsize, bool hasnan, bool descending) \
+    std::vector<size_t> argsort( \
+            TYPE *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
         return (*internal_argsort##TYPE)(arr, arrsize, hasnan, descending); \
     }

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -86,12 +86,12 @@ namespace x86simdsort {
     }
 
 #define DECLARE_INTERNAL_argsort(TYPE) \
-    static std::vector<size_t> (*internal_argsort##TYPE)(TYPE *, size_t, bool) \
+    static std::vector<size_t> (*internal_argsort##TYPE)(TYPE *, size_t, bool, bool) \
             = NULL; \
     template <> \
-    std::vector<size_t> argsort(TYPE *arr, size_t arrsize, bool hasnan) \
+    std::vector<size_t> argsort(TYPE *arr, size_t arrsize, bool hasnan, bool descending) \
     { \
-        return (*internal_argsort##TYPE)(arr, arrsize, hasnan); \
+        return (*internal_argsort##TYPE)(arr, arrsize, hasnan, descending); \
     }
 
 #define DECLARE_INTERNAL_argselect(TYPE) \

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -36,7 +36,7 @@ XSS_EXPORT_SYMBOL void partial_qsort(T *arr,
 // argsort
 template <typename T>
 XSS_EXPORT_SYMBOL std::vector<size_t>
-argsort(T *arr, size_t arrsize, bool hasnan = false);
+argsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
 
 // argselect
 template <typename T>

--- a/src/README.md
+++ b/src/README.md
@@ -13,8 +13,8 @@ Equivalent to `qsort` in
 `std::sort` in [C++](https://en.cppreference.com/w/cpp/algorithm/sort).
 
 ```cpp
-void avx512_qsort<T>(T* arr, size_t arrsize, bool hasnan = false);
-void avx2_qsort<T>(T* arr, size_t arrsize, bool hasnan = false);
+void avx512_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx2_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
 ```
 Supported datatypes: `uint16_t`, `int16_t`, `_Float16`, `uint32_t`, `int32_t`,
 `float`, `uint64_t`, `int64_t` and `double`. AVX2 versions currently support
@@ -30,8 +30,8 @@ Equivalent to `std::nth_element` in
 
 
 ```cpp
-void avx512_qselect<T>(T* arr, size_t arrsize, bool hasnan = false);
-void avx2_qselect<T>(T* arr, size_t arrsize, bool hasnan = false);
+void avx512_qselect<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx2_qselect<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
 ```
 Supported datatypes: `uint16_t`, `int16_t`, `_Float16`, `uint32_t`, `int32_t`,
 `float`, `uint64_t`, `int64_t` and `double`. AVX2 versions currently support
@@ -46,8 +46,8 @@ Equivalent to `std::partial_sort` in
 
 
 ```cpp
-void avx512_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false)
-void avx2_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false)
+void avx512_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false)
+void avx2_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false)
 ```
 Supported datatypes: `uint16_t`, `int16_t`, `_Float16`, `uint32_t`, `int32_t`,
 `float`, `uint64_t`, `int64_t` and `double`. AVX2 versions currently support
@@ -61,8 +61,8 @@ Equivalent to `np.argsort` in
 [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.argsort.html).
 
 ```cpp
-std::vector<size_t> arg = avx512_argsort<T>(T* arr, size_t arrsize);
-void avx512_argsort<T>(T* arr, size_t *arg, size_t arrsize);
+std::vector<size_t> arg = avx512_argsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx512_argsort<T>(T* arr, size_t *arg, size_t arrsize, bool hasnan = false, bool descending = false);
 ```
 Supported datatypes: `uint32_t`, `int32_t`, `float`, `uint64_t`, `int64_t` and
 `double`.
@@ -74,8 +74,8 @@ Equivalent to `np.argselect` in
 [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.argpartition.html).
 
 ```cpp
-std::vector<size_t> arg = avx512_argsort<T>(T* arr, size_t arrsize);
-void avx512_argsort<T>(T* arr, size_t *arg, size_t arrsize);
+std::vector<size_t> arg = avx512_argselect<T>(T* arr, size_t k, size_t arrsize);
+void avx512_argselect<T>(T* arr, size_t *arg, size_t k, size_t arrsize);
 ```
 Supported datatypes: `uint32_t`, `int32_t`, `float`, `uint64_t`, `int64_t` and
 `double`.

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -541,8 +541,11 @@ X86_SIMD_SORT_INLINE void argselect_64bit_(type_t *arr,
 
 /* argsort methods for 32-bit and 64-bit dtypes */
 template <typename T>
-X86_SIMD_SORT_INLINE void
-avx512_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false, bool descending = false)
+X86_SIMD_SORT_INLINE void avx512_argsort(T *arr,
+                                         arrsize_t *arg,
+                                         arrsize_t arrsize,
+                                         bool hasnan = false,
+                                         bool descending = false)
 {
     /* TODO optimization: on 32-bit, use zmm_vector for 32-bit dtype */
     using vectype = typename std::conditional<sizeof(T) == sizeof(int32_t),
@@ -558,27 +561,23 @@ avx512_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false, b
         if constexpr (std::is_floating_point_v<T>) {
             if ((hasnan) && (array_has_nan<vectype>(arr, arrsize))) {
                 std_argsort_withnan(arr, arg, 0, arrsize);
-                
-                if (descending){
-                    std::reverse(arg, arg + arrsize);
-                }
-                
+
+                if (descending) { std::reverse(arg, arg + arrsize); }
+
                 return;
             }
         }
         UNUSED(hasnan);
         argsort_64bit_<vectype, argtype>(
                 arr, arg, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
-        
-        if (descending){
-            std::reverse(arg, arg + arrsize);
-        }
+
+        if (descending) { std::reverse(arg, arg + arrsize); }
     }
 }
 
 template <typename T>
-X86_SIMD_SORT_INLINE std::vector<arrsize_t>
-avx512_argsort(T *arr, arrsize_t arrsize, bool hasnan = false, bool descending = false)
+X86_SIMD_SORT_INLINE std::vector<arrsize_t> avx512_argsort(
+        T *arr, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     std::vector<arrsize_t> indices(arrsize);
     std::iota(indices.begin(), indices.end(), 0);
@@ -588,8 +587,11 @@ avx512_argsort(T *arr, arrsize_t arrsize, bool hasnan = false, bool descending =
 
 /* argsort methods for 32-bit and 64-bit dtypes */
 template <typename T>
-X86_SIMD_SORT_INLINE void
-avx2_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false, bool descending = false)
+X86_SIMD_SORT_INLINE void avx2_argsort(T *arr,
+                                       arrsize_t *arg,
+                                       arrsize_t arrsize,
+                                       bool hasnan = false,
+                                       bool descending = false)
 {
     using vectype = typename std::conditional<sizeof(T) == sizeof(int32_t),
                                               avx2_half_vector<T>,
@@ -603,27 +605,23 @@ avx2_argsort(T *arr, arrsize_t *arg, arrsize_t arrsize, bool hasnan = false, boo
         if constexpr (std::is_floating_point_v<T>) {
             if ((hasnan) && (array_has_nan<vectype>(arr, arrsize))) {
                 std_argsort_withnan(arr, arg, 0, arrsize);
-                
-                if (descending){
-                    std::reverse(arg, arg + arrsize);
-                }
-                
+
+                if (descending) { std::reverse(arg, arg + arrsize); }
+
                 return;
             }
         }
         UNUSED(hasnan);
         argsort_64bit_<vectype, argtype>(
                 arr, arg, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
-        
-        if (descending){
-            std::reverse(arg, arg + arrsize);
-        }
+
+        if (descending) { std::reverse(arg, arg + arrsize); }
     }
 }
 
 template <typename T>
-X86_SIMD_SORT_INLINE std::vector<arrsize_t>
-avx2_argsort(T *arr, arrsize_t arrsize, bool hasnan = false, bool descending = false)
+X86_SIMD_SORT_INLINE std::vector<arrsize_t> avx2_argsort(
+        T *arr, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     std::vector<arrsize_t> indices(arrsize);
     std::iota(indices.begin(), indices.end(), 0);
@@ -649,7 +647,7 @@ X86_SIMD_SORT_INLINE void avx512_argselect(T *arr,
                                       ymm_vector<arrsize_t>,
                                       zmm_vector<arrsize_t>>::type;
 
-    if (arrsize > 1) {    
+    if (arrsize > 1) {
         if constexpr (std::is_floating_point_v<T>) {
             if ((hasnan) && (array_has_nan<vectype>(arr, arrsize))) {
                 std_argselect_withnan(arr, arg, k, 0, arrsize);

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -71,7 +71,7 @@ TYPED_TEST_P(simdsort, test_qsort_descending)
     }
 }
 
-TYPED_TEST_P(simdsort, test_argsort)
+TYPED_TEST_P(simdsort, test_argsort_ascending)
 {
     for (auto type : this->arrtype) {
         bool hasnan = (type == "rand_with_nan") ? true : false;
@@ -82,6 +82,24 @@ TYPED_TEST_P(simdsort, test_argsort)
                       sortedarr.end(),
                       compare<TypeParam, std::less<TypeParam>>());
             auto arg = x86simdsort::argsort(arr.data(), arr.size(), hasnan);
+            IS_ARG_SORTED(sortedarr, arr, arg, type);
+            arr.clear();
+            arg.clear();
+        }
+    }
+}
+
+TYPED_TEST_P(simdsort, test_argsort_descending)
+{
+    for (auto type : this->arrtype) {
+        bool hasnan = (type == "rand_with_nan") ? true : false;
+        for (auto size : this->arrsize) {
+            std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
+            std::vector<TypeParam> sortedarr = arr;
+            std::sort(sortedarr.begin(),
+                      sortedarr.end(),
+                      compare<TypeParam, std::greater<TypeParam>>());
+            auto arg = x86simdsort::argsort(arr.data(), arr.size(), hasnan, true);
             IS_ARG_SORTED(sortedarr, arr, arg, type);
             arr.clear();
             arg.clear();
@@ -241,7 +259,8 @@ TYPED_TEST_P(simdsort, test_comparator)
 REGISTER_TYPED_TEST_SUITE_P(simdsort,
                             test_qsort_ascending,
                             test_qsort_descending,
-                            test_argsort,
+                            test_argsort_ascending,
+                            test_argsort_descending,
                             test_argselect,
                             test_qselect_ascending,
                             test_qselect_descending,

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -99,7 +99,8 @@ TYPED_TEST_P(simdsort, test_argsort_descending)
             std::sort(sortedarr.begin(),
                       sortedarr.end(),
                       compare<TypeParam, std::greater<TypeParam>>());
-            auto arg = x86simdsort::argsort(arr.data(), arr.size(), hasnan, true);
+            auto arg = x86simdsort::argsort(
+                    arr.data(), arr.size(), hasnan, true);
             IS_ARG_SORTED(sortedarr, arr, arg, type);
             arr.clear();
             arg.clear();


### PR DESCRIPTION
This patch adds support for descending argsort and tests for it.

```
Comparing simdargsort.*random_1 to simd_revargsort.*random_1 (from ./benchexe)
Benchmark                                                                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/int64_t                  +0.0351         +0.0352           700           724           700           724
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/int64_t                   +0.0106         +0.0106         10495         10607         10495         10606
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/int64_t                 +0.0127         +0.0128       1984814       2010041       1984600       2010030
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/int64_t                   +0.0125         +0.0127      35326504      35769670      35321177      35768358
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/int64_t                  -0.0015         -0.0015    1008048326    1006544869    1007932916    1006469941
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/int64_t                 -0.0008         -0.0007   18740949217   18725879386   18738472186   18724539794
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/uint64_t                 +0.0265         +0.0266           713           732           713           732
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/uint64_t                  +0.0110         +0.0111         10492         10607         10491         10607
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/uint64_t                +0.0089         +0.0090       1984786       2002470       1984602       2002367
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/uint64_t                  +0.0142         +0.0144      35019575      35517267      35011788      35514938
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/uint64_t                 +0.0014         +0.0015    1005610608    1006975763    1005453293    1006926654
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/uint64_t                -0.0016         -0.0015   18755431656   18725763887   18753024082   18724198698
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/double                   +0.0341         +0.0341           599           620           599           620
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/double                    +0.0134         +0.0134          9352          9477          9351          9477
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/double                  +0.0081         +0.0081       1936659       1952396       1936464       1952241
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/double                    +0.0138         +0.0138      34428106      34903675      34426293      34900722
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/double                   -0.0006         -0.0005    1009933569    1009357736    1009741924    1009258251
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/double                  -0.0010         -0.0009   18553309038   18535103083   18550992608   18533609826
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/int32_t                  +0.0138         +0.0138           621           629           621           629
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/int32_t                   +0.0173         +0.0173         10487         10668         10486         10668
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/int32_t                 +0.0187         +0.0187       1715798       1747838       1715659       1747715
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/int32_t                   +0.0159         +0.0160      27752094      28193729      27747527      28191687
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/int32_t                  +0.0003         +0.0004     813506313     813786134     813346264     813637191
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/int32_t                 -0.0026         -0.0026   16372721091   16329909619   16370509091   16328529689
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/uint32_t                 +0.0167         +0.0167           620           631           620           631
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/uint32_t                  +0.0160         +0.0161         10499         10667         10498         10667
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/uint32_t                +0.0081         +0.0081       1726447       1740387       1726247       1740274
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/uint32_t                  +0.0087         +0.0088      27792174      28034826      27789285      28034417
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/uint32_t                 +0.0010         +0.0010     813359007     814143233     813226954     814051882
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/uint32_t                -0.0024         -0.0024   16363564108   16323686834   16361610455   16322444405
[simdargsort.*random_1 vs. simd_revargsort.*random_1]28/float                    +0.0235         +0.0236           667           683           667           683
[simdargsort.*random_1 vs. simd_revargsort.*random_1]k/float                     +0.0138         +0.0138          9924         10060          9923         10060
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00k/float                   +0.0121         +0.0122       1811155       1833046       1810910       1832930
[simdargsort.*random_1 vs. simd_revargsort.*random_1]m/float                     +0.0074         +0.0074      28442530      28653620      28439292      28649646
[simdargsort.*random_1 vs. simd_revargsort.*random_1]0m/float                    +0.0008         +0.0008     824497949     825123277     824381667     825026386
[simdargsort.*random_1 vs. simd_revargsort.*random_1]00m/float                   -0.0040         -0.0040   16435398683   16369311769   16433216995   16368255149
OVERALL_GEOMEAN                                                                  +0.0100         +0.0101             0             0             0             0

```