### PR TITLE
AVX2 Support for key-value sorting

### DIFF
--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -1,4 +1,5 @@
 // AVX2 specific routines:
+
 #include "x86simdsort-static-incl.h"
 #include "x86simdsort-internal.h"
 
@@ -33,6 +34,38 @@
         return x86simdsortStatic::argselect(arr, k, arrsize, hasnan); \
     }
 
+#define DEFINE_KEYVALUE_METHODS(type) \
+    template <> \
+    void keyvalue_qsort(type *key, uint64_t *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    } \
+    template <> \
+    void keyvalue_qsort(type *key, int64_t *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    } \
+    template <> \
+    void keyvalue_qsort(type *key, double *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    } \
+    template <> \
+    void keyvalue_qsort(type *key, uint32_t *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    } \
+    template <> \
+    void keyvalue_qsort(type *key, int32_t *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    } \
+    template <> \
+    void keyvalue_qsort(type *key, float *val, size_t arrsize, bool hasnan) \
+    { \
+        avx2_qsort_kv(key, val, arrsize, hasnan); \
+    }
+
 namespace xss {
 namespace avx2 {
     DEFINE_ALL_METHODS(uint32_t)
@@ -41,5 +74,11 @@ namespace avx2 {
     DEFINE_ALL_METHODS(uint64_t)
     DEFINE_ALL_METHODS(int64_t)
     DEFINE_ALL_METHODS(double)
+    DEFINE_KEYVALUE_METHODS(uint64_t)
+    DEFINE_KEYVALUE_METHODS(int64_t)
+    DEFINE_KEYVALUE_METHODS(double)
+    DEFINE_KEYVALUE_METHODS(uint32_t)
+    DEFINE_KEYVALUE_METHODS(int32_t)
+    DEFINE_KEYVALUE_METHODS(float)
 } // namespace avx2
 } // namespace xss

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -38,32 +38,32 @@
     template <> \
     void keyvalue_qsort(type *key, uint64_t *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
     void keyvalue_qsort(type *key, int64_t *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
     void keyvalue_qsort(type *key, double *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
     void keyvalue_qsort(type *key, uint32_t *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
     void keyvalue_qsort(type *key, int32_t *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
     void keyvalue_qsort(type *key, float *val, size_t arrsize, bool hasnan) \
     { \
-        avx2_qsort_kv(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     }
 
 namespace xss {

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -1,4 +1,5 @@
 // SKX specific routines:
+
 #include "x86simdsort-static-incl.h"
 #include "x86simdsort-internal.h"
 

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -208,12 +208,12 @@ DISPATCH_ALL(argselect,
              (ISA_LIST("avx512_skx", "avx2")))
 
 #define DISPATCH_KEYVALUE_SORT_FORTYPE(type) \
-    DISPATCH_KEYVALUE_SORT(type, uint64_t, (ISA_LIST("avx512_skx"))) \
-    DISPATCH_KEYVALUE_SORT(type, int64_t, (ISA_LIST("avx512_skx"))) \
-    DISPATCH_KEYVALUE_SORT(type, double, (ISA_LIST("avx512_skx"))) \
-    DISPATCH_KEYVALUE_SORT(type, uint32_t, (ISA_LIST("avx512_skx"))) \
-    DISPATCH_KEYVALUE_SORT(type, int32_t, (ISA_LIST("avx512_skx"))) \
-    DISPATCH_KEYVALUE_SORT(type, float, (ISA_LIST("avx512_skx")))
+    DISPATCH_KEYVALUE_SORT(type, uint64_t, (ISA_LIST("avx512_skx", "avx2"))) \
+    DISPATCH_KEYVALUE_SORT(type, int64_t, (ISA_LIST("avx512_skx", "avx2"))) \
+    DISPATCH_KEYVALUE_SORT(type, double, (ISA_LIST("avx512_skx", "avx2"))) \
+    DISPATCH_KEYVALUE_SORT(type, uint32_t, (ISA_LIST("avx512_skx", "avx2"))) \
+    DISPATCH_KEYVALUE_SORT(type, int32_t, (ISA_LIST("avx512_skx", "avx2"))) \
+    DISPATCH_KEYVALUE_SORT(type, float, (ISA_LIST("avx512_skx", "avx2")))
 
 DISPATCH_KEYVALUE_SORT_FORTYPE(uint64_t)
 DISPATCH_KEYVALUE_SORT_FORTYPE(int64_t)

--- a/src/avx2-32bit-qsort.hpp
+++ b/src/avx2-32bit-qsort.hpp
@@ -99,7 +99,8 @@ struct avx2_vector<int32_t> {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
     }
-    static opmask_t convert_int_to_mask(uint64_t intMask){
+    static opmask_t convert_int_to_mask(uint64_t intMask)
+    {
         return convert_int_to_avx2_mask(intMask);
     }
     static ymmi_t
@@ -271,7 +272,8 @@ struct avx2_vector<uint32_t> {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
     }
-    static opmask_t convert_int_to_mask(uint64_t intMask){
+    static opmask_t convert_int_to_mask(uint64_t intMask)
+    {
         return convert_int_to_avx2_mask(intMask);
     }
     static ymmi_t
@@ -450,7 +452,8 @@ struct avx2_vector<float> {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
     }
-    static opmask_t convert_int_to_mask(uint64_t intMask){
+    static opmask_t convert_int_to_mask(uint64_t intMask)
+    {
         return convert_int_to_avx2_mask(intMask);
     }
     static int32_t convert_mask_to_int(opmask_t mask)

--- a/src/avx2-32bit-qsort.hpp
+++ b/src/avx2-32bit-qsort.hpp
@@ -99,6 +99,9 @@ struct avx2_vector<int32_t> {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
     }
+    static opmask_t convert_int_to_mask(uint64_t intMask){
+        return convert_int_to_avx2_mask(intMask);
+    }
     static ymmi_t
     seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
     {
@@ -267,6 +270,9 @@ struct avx2_vector<uint32_t> {
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
+    }
+    static opmask_t convert_int_to_mask(uint64_t intMask){
+        return convert_int_to_avx2_mask(intMask);
     }
     static ymmi_t
     seti(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
@@ -443,6 +449,9 @@ struct avx2_vector<float> {
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
         return convert_int_to_avx2_mask(mask);
+    }
+    static opmask_t convert_int_to_mask(uint64_t intMask){
+        return convert_int_to_avx2_mask(intMask);
     }
     static int32_t convert_mask_to_int(opmask_t mask)
     {

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -24,6 +24,7 @@ template <typename vtype, typename reg_t>
 X86_SIMD_SORT_INLINE reg_t sort_zmm_64bit(reg_t zmm);
 
 struct avx512_64bit_swizzle_ops;
+struct avx512_ymm_64bit_swizzle_ops;
 
 template <>
 struct ymm_vector<float> {
@@ -33,6 +34,8 @@ struct ymm_vector<float> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
+    
+    using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()
     {
@@ -212,6 +215,14 @@ struct ymm_vector<float> {
         const __m256i rev_index = _mm256_set_epi32(NETWORK_32BIT_AVX2_2);
         return permutexvar(rev_index, ymm);
     }
+    static int double_compressstore(type_t *left_addr,
+                                    type_t *right_addr,
+                                    opmask_t k,
+                                    reg_t reg)
+    {
+        return avx512_double_compressstore<ymm_vector<type_t>>(
+                left_addr, right_addr, k, reg);
+    }
 };
 template <>
 struct ymm_vector<uint32_t> {
@@ -221,6 +232,8 @@ struct ymm_vector<uint32_t> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
+    
+    using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()
     {
@@ -386,6 +399,14 @@ struct ymm_vector<uint32_t> {
         const __m256i rev_index = _mm256_set_epi32(NETWORK_32BIT_AVX2_2);
         return permutexvar(rev_index, ymm);
     }
+    static int double_compressstore(type_t *left_addr,
+                                    type_t *right_addr,
+                                    opmask_t k,
+                                    reg_t reg)
+    {
+        return avx512_double_compressstore<ymm_vector<type_t>>(
+                left_addr, right_addr, k, reg);
+    }
 };
 template <>
 struct ymm_vector<int32_t> {
@@ -395,6 +416,8 @@ struct ymm_vector<int32_t> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
+    
+    using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()
     {
@@ -559,6 +582,14 @@ struct ymm_vector<int32_t> {
     {
         const __m256i rev_index = _mm256_set_epi32(NETWORK_32BIT_AVX2_2);
         return permutexvar(rev_index, ymm);
+    }
+    static int double_compressstore(type_t *left_addr,
+                                    type_t *right_addr,
+                                    opmask_t k,
+                                    reg_t reg)
+    {
+        return avx512_double_compressstore<ymm_vector<type_t>>(
+                left_addr, right_addr, k, reg);
     }
 };
 template <>
@@ -1206,6 +1237,79 @@ struct avx512_64bit_swizzle_ops {
         }
         else if constexpr (scale == 8) {
             v1 = _mm512_mask_blend_epi64(0b00001111, v1, v2);
+        }
+        else {
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(v1);
+    }
+};
+
+struct avx512_ymm_64bit_swizzle_ops {
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t swap_n(typename vtype::reg_t reg)
+    {
+        __m256i v = vtype::cast_to(reg);
+
+        if constexpr (scale == 2) {
+            __m256 vf = _mm256_castsi256_ps(v);
+            vf = _mm256_permute_ps(vf, 0b10110001);
+            v = _mm256_castps_si256(vf);
+        }
+        else if constexpr (scale == 4) {
+            __m256 vf = _mm256_castsi256_ps(v);
+            vf = _mm256_permute_ps(vf, 0b01001110);
+            v = _mm256_castps_si256(vf);
+        }
+        else if constexpr (scale == 8) {
+            v = _mm256_permute2x128_si256(v, v, 0b00000001);
+        }
+        else {
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(v);
+    }
+
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t
+    reverse_n(typename vtype::reg_t reg)
+    {
+        __m256i v = vtype::cast_to(reg);
+
+        if constexpr (scale == 2) { return swap_n<vtype, 2>(reg); }
+        else if constexpr (scale == 4) {
+            constexpr uint64_t mask = 0b00011011;
+            __m256 vf = _mm256_castsi256_ps(v);
+            vf = _mm256_permute_ps(vf, mask);
+            v = _mm256_castps_si256(vf);
+        }
+        else if constexpr (scale == 8) {
+            return vtype::reverse(reg);
+        }
+        else {
+            static_assert(scale == -1, "should not be reached");
+        }
+
+        return vtype::cast_from(v);
+    }
+
+    template <typename vtype, int scale>
+    X86_SIMD_SORT_INLINE typename vtype::reg_t
+    merge_n(typename vtype::reg_t reg, typename vtype::reg_t other)
+    {
+        __m256i v1 = vtype::cast_to(reg);
+        __m256i v2 = vtype::cast_to(other);
+
+        if constexpr (scale == 2) {
+            v1 = _mm256_blend_epi32(v1, v2, 0b01010101);
+        }
+        else if constexpr (scale == 4) {
+            v1 = _mm256_blend_epi32(v1, v2, 0b00110011);
+        }
+        else if constexpr (scale == 8) {
+            v1 = _mm256_blend_epi32(v1, v2, 0b00001111);
         }
         else {
             static_assert(scale == -1, "should not be reached");

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -34,7 +34,7 @@ struct ymm_vector<float> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
-    
+
     using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()
@@ -232,7 +232,7 @@ struct ymm_vector<uint32_t> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
-    
+
     using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()
@@ -416,7 +416,7 @@ struct ymm_vector<int32_t> {
     using opmask_t = __mmask8;
     static const uint8_t numlanes = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
-    
+
     using swizzle_ops = avx512_ymm_64bit_swizzle_ops;
 
     static type_t type_max()

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -100,6 +100,12 @@ keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
         std::iota(indices.begin(), indices.end(), 0); \
         x86simdsortStatic::argselect(arr, indices.data(), k, size, hasnan); \
         return indices; \
+    } \
+    template <typename T1, typename T2> \
+    X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_qsort( \
+            T1 *key, T2 *val, size_t size, bool hasnan) \
+    { \
+        ISA##_qsort_kv(key, val, size, hasnan); \
     }
 
 /*
@@ -107,13 +113,13 @@ keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
  */
 #include "xss-common-qsort.h"
 #include "xss-common-argsort.h"
+#include "xss-common-keyvaluesort.hpp"
 
 #if defined(__AVX512DQ__) && defined(__AVX512VL__)
 /* 32-bit and 64-bit dtypes vector definitions on SKX */
 #include "avx512-32bit-qsort.hpp"
 #include "avx512-64bit-qsort.hpp"
 #include "avx512-64bit-argsort.hpp"
-#include "avx512-64bit-keyvaluesort.hpp"
 
 /* 16-bit dtypes vector definitions on ICL */
 #if defined(__AVX512BW__) && defined(__AVX512VBMI2__)
@@ -125,14 +131,6 @@ keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
 #endif // __AVX512VBMI2__
 
 XSS_METHODS(avx512)
-
-// key-value currently only on avx512
-template <typename T1, typename T2>
-X86_SIMD_SORT_FINLINE void
-x86simdsortStatic::keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan)
-{
-    avx512_qsort_kv(key, val, size, hasnan);
-}
 
 #elif defined(__AVX512F__)
 #error "x86simdsort requires AVX512DQ and AVX512VL to be enabled in addition to AVX512F to use AVX512"

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -34,10 +34,14 @@ X86_SIMD_SORT_INLINE int32_t partition_vec(type_t1 *keys,
 {
     /* which elements are larger than the pivot */
     typename vtype1::opmask_t gt_mask = vtype1::ge(keys_vec, pivot_vec);
-    
-    int32_t amount_gt_pivot = vtype1::double_compressstore(keys + left, keys + right - vtype1::numlanes, gt_mask, keys_vec);
-    vtype2::double_compressstore(indexes + left, indexes + right - vtype2::numlanes, resize_mask<vtype1, vtype2>(gt_mask), indexes_vec);
-    
+
+    int32_t amount_gt_pivot = vtype1::double_compressstore(
+            keys + left, keys + right - vtype1::numlanes, gt_mask, keys_vec);
+    vtype2::double_compressstore(indexes + left,
+                                 indexes + right - vtype2::numlanes,
+                                 resize_mask<vtype1, vtype2>(gt_mask),
+                                 indexes_vec);
+
     *smallest_vec = vtype1::min(keys_vec, *smallest_vec);
     *biggest_vec = vtype1::max(keys_vec, *biggest_vec);
     return amount_gt_pivot;
@@ -457,7 +461,8 @@ avx2_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
         if constexpr (std::is_floating_point_v<T1>) {
             arrsize_t nan_count = 0;
             if (UNLIKELY(hasnan)) {
-                nan_count = replace_nan_with_inf<avx2_vector<T1>>(keys, arrsize);
+                nan_count
+                        = replace_nan_with_inf<avx2_vector<T1>>(keys, arrsize);
             }
             qsort_64bit_<keytype, valtype>(keys,
                                            indexes,

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -8,7 +8,6 @@
 #ifndef AVX512_QSORT_64BIT_KV
 #define AVX512_QSORT_64BIT_KV
 
-
 #include "xss-common-qsort.h"
 #include "xss-network-keyvaluesort.hpp"
 
@@ -437,20 +436,12 @@ xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan)
                 nan_count
                         = replace_nan_with_inf<full_vector<T1>>(keys, arrsize);
             }
-            kvsort_<keytype, valtype>(keys,
-                                      indexes,
-                                      0,
-                                      arrsize - 1,
-                                      2 * (arrsize_t)log2(arrsize));
+            kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
             replace_inf_with_nan(keys, arrsize, nan_count);
         }
         else {
             UNUSED(hasnan);
-            kvsort_<keytype, valtype>(keys,
-                                      indexes,
-                                      0,
-                                      arrsize - 1,
-                                      2 * (arrsize_t)log2(arrsize));
+            kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
         }
     }
 }

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -430,19 +430,18 @@ xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan)
 #endif // XSS_TEST_KEYVALUE_BASE_CASE
 
     if (minarrsize) {
-        if constexpr (std::is_floating_point_v<T1>) {
-            arrsize_t nan_count = 0;
+        arrsize_t nan_count = 0;
+        if constexpr (xss::fp::is_floating_point_v<T1>) {
             if (UNLIKELY(hasnan)) {
                 nan_count
                         = replace_nan_with_inf<full_vector<T1>>(keys, arrsize);
             }
-            kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
-            replace_inf_with_nan(keys, arrsize, nan_count);
         }
         else {
             UNUSED(hasnan);
-            kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
         }
+        kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
+        replace_inf_with_nan(keys, arrsize, nan_count);
     }
 }
 

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -189,9 +189,6 @@ X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b)
     b = vtype::max(temp, b);
 }
 
-template <typename maskType, typename vtype>
-typename vtype::opmask_t convert_int_to_mask(maskType mask);
-
 template <typename vtype,
           typename reg_t = typename vtype::reg_t,
           typename opmask_t = typename vtype::opmask_t>

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -189,6 +189,9 @@ X86_SIMD_SORT_INLINE void COEX(mm_t &a, mm_t &b)
     b = vtype::max(temp, b);
 }
 
+template <typename maskType, typename vtype>
+typename vtype::opmask_t convert_int_to_mask(maskType mask);
+
 template <typename vtype,
           typename reg_t = typename vtype::reg_t,
           typename opmask_t = typename vtype::opmask_t>

--- a/src/xss-network-keyvaluesort.hpp
+++ b/src/xss-network-keyvaluesort.hpp
@@ -1,6 +1,19 @@
 #ifndef XSS_KEYVALUE_NETWORKS
 #define XSS_KEYVALUE_NETWORKS
 
+#include "xss-common-includes.h"
+
+template <typename vtype, typename maskType>
+typename vtype::opmask_t convert_int_to_mask(maskType mask){
+    if constexpr (vtype::vec_type == simd_type::AVX512) {
+        return mask;
+    }else if constexpr (vtype::vec_type == simd_type::AVX2){
+        return vtype::convert_int_to_mask(mask);
+    }else{
+        static_assert(always_false<maskType>, "Error in func convert_int_to_mask");
+    }
+}
+
 template <typename keyType, typename valueType>
 typename valueType::opmask_t resize_mask(typename keyType::opmask_t mask)
 {
@@ -70,66 +83,74 @@ template <typename vtype1,
 X86_SIMD_SORT_INLINE reg_t sort_reg_16lanes(reg_t key_zmm,
                                             index_type &index_zmm)
 {
+    using key_swizzle = typename vtype1::swizzle_ops;
+    using index_swizzle = typename vtype2::swizzle_ops;
+    
+    const auto oxAAAA = convert_int_to_mask<vtype1>(0xAAAA);
+    const auto oxCCCC = convert_int_to_mask<vtype1>(0xCCCC);
+    const auto oxFF00 = convert_int_to_mask<vtype1>(0xFF00);
+    const auto oxF0F0 = convert_int_to_mask<vtype1>(0xF0F0);
+    
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
-            0xAAAA);
+            index_swizzle::template reverse_n<vtype2, 2>(index_zmm),
+            oxAAAA);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(0, 1, 2, 3)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 4>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(0, 1, 2, 3)>(index_zmm),
-            0xCCCC);
+            index_swizzle::template reverse_n<vtype2, 4>(index_zmm),
+            oxCCCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
-            0xAAAA);
+            index_swizzle::template reverse_n<vtype2, 2>(index_zmm),
+            oxAAAA);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_3), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_3), index_zmm),
-            0xF0F0);
+            oxF0F0);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 4>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
-            0xCCCC);
+            index_swizzle::template swap_n<vtype2, 4>(index_zmm),
+            oxCCCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
-            0xAAAA);
+            index_swizzle::template reverse_n<vtype2, 2>(index_zmm),
+            oxAAAA);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_5), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_5), index_zmm),
-            0xFF00);
+            oxFF00);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_6), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_6), index_zmm),
-            0xF0F0);
+            oxF0F0);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 4>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
-            0xCCCC);
+            index_swizzle::template swap_n<vtype2, 4>(index_zmm),
+            oxCCCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
-            0xAAAA);
+            index_swizzle::template reverse_n<vtype2, 2>(index_zmm),
+            oxAAAA);
     return key_zmm;
 }
 
@@ -141,30 +162,38 @@ template <typename vtype1,
 X86_SIMD_SORT_INLINE reg_t bitonic_merge_reg_16lanes(reg_t key_zmm,
                                                      index_type &index_zmm)
 {
+    using key_swizzle = typename vtype1::swizzle_ops;
+    using index_swizzle = typename vtype2::swizzle_ops;
+    
+    const auto oxAAAA = convert_int_to_mask<vtype1>(0xAAAA);
+    const auto oxCCCC = convert_int_to_mask<vtype1>(0xCCCC);
+    const auto oxFF00 = convert_int_to_mask<vtype1>(0xFF00);
+    const auto oxF0F0 = convert_int_to_mask<vtype1>(0xF0F0);
+    
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_7), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_7), index_zmm),
-            0xFF00);
+            oxFF00);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_32BIT_6), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_32BIT_6), index_zmm),
-            0xF0F0);
+            oxF0F0);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 4>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 0, 3, 2)>(index_zmm),
-            0xCCCC);
+            index_swizzle::template swap_n<vtype2, 4>(index_zmm),
+            oxCCCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(key_zmm),
+            key_swizzle::template reverse_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(2, 3, 0, 1)>(index_zmm),
-            0xAAAA);
+            index_swizzle::template reverse_n<vtype2, 2>(index_zmm),
+            oxAAAA);
     return key_zmm;
 }
 
@@ -173,45 +202,50 @@ template <typename vtype1,
           typename reg_t = typename vtype1::reg_t,
           typename index_type = typename vtype2::reg_t>
 X86_SIMD_SORT_INLINE reg_t sort_reg_8lanes(reg_t key_zmm, index_type &index_zmm)
-{
-    const typename vtype1::regi_t rev_index1 = vtype1::seti(NETWORK_64BIT_2);
-    const typename vtype2::regi_t rev_index2 = vtype2::seti(NETWORK_64BIT_2);
+{   
+    using key_swizzle = typename vtype1::swizzle_ops;
+    using index_swizzle = typename vtype2::swizzle_ops;
+
+    const auto oxAA = convert_int_to_mask<vtype1>(0xAA);
+    const auto oxCC = convert_int_to_mask<vtype1>(0xCC);
+    const auto oxF0 = convert_int_to_mask<vtype1>(0xF0);
+    
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(index_zmm),
-            0xAA);
+            index_swizzle::template swap_n<vtype2, 2>(index_zmm),
+            oxAA);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_64BIT_1), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_64BIT_1), index_zmm),
-            0xCC);
+            oxCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(index_zmm),
-            0xAA);
+            index_swizzle::template swap_n<vtype2, 2>(index_zmm),
+            oxAA);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::permutexvar(rev_index1, key_zmm),
+            vtype1::reverse(key_zmm),
             index_zmm,
-            vtype2::permutexvar(rev_index2, index_zmm),
-            0xF0);
+            vtype2::reverse(index_zmm),
+            oxF0);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_64BIT_3), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_64BIT_3), index_zmm),
-            0xCC);
+            oxCC);
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(index_zmm),
-            0xAA);
+            index_swizzle::template swap_n<vtype2, 2>(index_zmm),
+            oxAA);
     return key_zmm;
 }
 
@@ -255,6 +289,12 @@ template <typename vtype1,
 X86_SIMD_SORT_INLINE reg_t bitonic_merge_reg_8lanes(reg_t key_zmm,
                                                     index_type &index_zmm)
 {
+    using key_swizzle = typename vtype1::swizzle_ops;
+    using index_swizzle = typename vtype2::swizzle_ops;
+    
+    const auto oxAA = convert_int_to_mask<vtype1>(0xAA);
+    const auto oxCC = convert_int_to_mask<vtype1>(0xCC);
+    const auto oxF0 = convert_int_to_mask<vtype1>(0xF0);
 
     // 1) half_cleaner[8]: compare 0-4, 1-5, 2-6, 3-7
     key_zmm = cmp_merge<vtype1, vtype2>(
@@ -262,21 +302,21 @@ X86_SIMD_SORT_INLINE reg_t bitonic_merge_reg_8lanes(reg_t key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_64BIT_4), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_64BIT_4), index_zmm),
-            0xF0);
+            oxF0);
     // 2) half_cleaner[4]
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
             vtype1::permutexvar(vtype1::seti(NETWORK_64BIT_3), key_zmm),
             index_zmm,
             vtype2::permutexvar(vtype2::seti(NETWORK_64BIT_3), index_zmm),
-            0xCC);
+            oxCC);
     // 3) half_cleaner[1]
     key_zmm = cmp_merge<vtype1, vtype2>(
             key_zmm,
-            vtype1::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(key_zmm),
+            key_swizzle::template swap_n<vtype1, 2>(key_zmm),
             index_zmm,
-            vtype2::template shuffle<SHUFFLE_MASK(1, 1, 1, 1)>(index_zmm),
-            0xAA);
+            index_swizzle::template swap_n<vtype2, 2>(index_zmm),
+            oxAA);
     return key_zmm;
 }
 
@@ -553,7 +593,7 @@ X86_SIMD_SORT_INLINE void kvsort_n_vec(typename keyType::type_t *keys,
         keyVecs[i] = keyType::mask_loadu(
                 keyType::zmm_max(), ioMasks[j], keys + i * keyType::numlanes);
         valueVecs[i] = valueType::mask_loadu(valueType::zmm_max(),
-                                             ioMasks[j],
+                                             resize_mask<keyType, valueType>(ioMasks[j]),
                                              values + i * valueType::numlanes);
     }
 
@@ -578,7 +618,7 @@ X86_SIMD_SORT_INLINE void kvsort_n_vec(typename keyType::type_t *keys,
         keyType::mask_storeu(
                 keys + i * keyType::numlanes, ioMasks[j], keyVecs[i]);
         valueType::mask_storeu(
-                values + i * valueType::numlanes, ioMasks[j], valueVecs[i]);
+                values + i * valueType::numlanes, resize_mask<keyType, valueType>(ioMasks[j]), valueVecs[i]);
     }
 }
 


### PR DESCRIPTION
This patch adds support for AVX2 key-value sorting. For comparison, benchmarks comparing the AVX2 vs. AVX512 performance and AVX2 vs. scalar performance are below:

<details>
<summary><b>AVX2</b></summary>

```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
simdkvsort/random_128/uint64_t        1939 ns         1946 ns       360240
simdkvsort/random_1k/uint64_t        18021 ns        18029 ns        39110
simdkvsort/random_100k/uint64_t    2359494 ns      2359426 ns          298
simdkvsort/random_1m/uint64_t     27181339 ns     27180247 ns           26
simdkvsort/random_10m/uint64_t   328366429 ns    328336094 ns            2
simdkvsort/random_100m/uint64_t 3818560389 ns   3818247990 ns            1
simdkvsort/random_128/int64_t         1939 ns         1948 ns       359936
simdkvsort/random_1k/int64_t         16188 ns        16201 ns        43224
simdkvsort/random_100k/int64_t     2094296 ns      2094317 ns          335
simdkvsort/random_1m/int64_t      24546170 ns     24543133 ns           28
simdkvsort/random_10m/int64_t    300429155 ns    300408697 ns            2
simdkvsort/random_100m/int64_t  3539816011 ns   3539431827 ns            1
simdkvsort/random_128/double          1657 ns         1665 ns       420794
simdkvsort/random_1k/double          13263 ns        13268 ns        52672
simdkvsort/random_100k/double      1707007 ns      1706945 ns          411
simdkvsort/random_1m/double       20710996 ns     20709242 ns           34
simdkvsort/random_10m/double     264312414 ns    264284784 ns            3
simdkvsort/random_100m/double   3124498665 ns   3124159045 ns            1
simdkvsort/random_128/uint32_t        1117 ns         1120 ns       626058
simdkvsort/random_1k/uint32_t         6418 ns         6428 ns       109035
simdkvsort/random_100k/uint32_t     884360 ns       884394 ns          791
simdkvsort/random_1m/uint32_t     10349431 ns     10348265 ns           68
simdkvsort/random_10m/uint32_t   129223761 ns    129208665 ns            5
simdkvsort/random_100m/uint32_t 1529426690 ns   1529322850 ns            1
simdkvsort/random_128/int32_t         1117 ns         1120 ns       625407
simdkvsort/random_1k/int32_t          6465 ns         6473 ns       108458
simdkvsort/random_100k/int32_t      922079 ns       922080 ns          758
simdkvsort/random_1m/int32_t      10840572 ns     10839740 ns           65
simdkvsort/random_10m/int32_t    134945071 ns    134931366 ns            5
simdkvsort/random_100m/int32_t  1591200513 ns   1591027400 ns            1
simdkvsort/random_128/float           1205 ns         1209 ns       578252
simdkvsort/random_1k/float            7378 ns         7390 ns        94558
simdkvsort/random_100k/float        975399 ns       975467 ns          716
simdkvsort/random_1m/float        11259949 ns     11258612 ns           62
simdkvsort/random_10m/float      138409369 ns    138397578 ns            5
simdkvsort/random_100m/float    1634287725 ns   1634146491 ns            1
```

</details>

<details>
<summary><b>AVX512</b></summary>

```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
simdkvsort/random_128/uint64_t        1174 ns         1177 ns       575703
simdkvsort/random_1k/uint64_t         7565 ns         7572 ns        92599
simdkvsort/random_100k/uint64_t    1099925 ns      1100012 ns          637
simdkvsort/random_1m/uint64_t     14643507 ns     14642890 ns           48
simdkvsort/random_10m/uint64_t   199687140 ns    199670122 ns            4
simdkvsort/random_100m/uint64_t 2487791770 ns   2487510844 ns            1
simdkvsort/random_128/int64_t         1177 ns         1180 ns       593556
simdkvsort/random_1k/int64_t          7617 ns         7625 ns        92009
simdkvsort/random_100k/int64_t     1099157 ns      1099172 ns          638
simdkvsort/random_1m/int64_t      14583034 ns     14581973 ns           48
simdkvsort/random_10m/int64_t    199769132 ns    199758441 ns            4
simdkvsort/random_100m/int64_t  2486518465 ns   2486306230 ns            1
simdkvsort/random_128/double          1079 ns         1081 ns       643342
simdkvsort/random_1k/double           6218 ns         6225 ns       112379
simdkvsort/random_100k/double      1005576 ns      1005649 ns          694
simdkvsort/random_1m/double       13543725 ns     13542388 ns           52
simdkvsort/random_10m/double     189044901 ns    189014084 ns            4
simdkvsort/random_100m/double   2369940116 ns   2369678581 ns            1
simdkvsort/random_128/uint32_t         878 ns          880 ns       795229
simdkvsort/random_1k/uint32_t         3586 ns         3588 ns       195088
simdkvsort/random_100k/uint32_t     548641 ns       548656 ns         1278
simdkvsort/random_1m/uint32_t      6862367 ns      6862099 ns          102
simdkvsort/random_10m/uint32_t    95574488 ns     95569892 ns            7
simdkvsort/random_100m/uint32_t 1191578120 ns   1191506814 ns            1
simdkvsort/random_128/int32_t          877 ns          879 ns       796114
simdkvsort/random_1k/int32_t          3591 ns         3594 ns       194537
simdkvsort/random_100k/int32_t      545403 ns       545420 ns         1272
simdkvsort/random_1m/int32_t       6858498 ns      6857780 ns          103
simdkvsort/random_10m/int32_t     95449697 ns     95438473 ns            7
simdkvsort/random_100m/int32_t  1190093444 ns   1190017700 ns            1
simdkvsort/random_128/float            942 ns          944 ns       744034
simdkvsort/random_1k/float            4677 ns         4679 ns       149366
simdkvsort/random_100k/float        622690 ns       622691 ns         1125
simdkvsort/random_1m/float         7654461 ns      7654027 ns           91
simdkvsort/random_10m/float      102934181 ns    102924527 ns            7
simdkvsort/random_100m/float    1270152278 ns   1269981042 ns            1
```

</details>

<details>
<summary><b>AVX2 vs. Scalar</b></summary>

```
Benchmark                                                                        Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------------------------------
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/uint64_t                +0.1078         +0.1102          1798          1992          1801          1999
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/int64_t                 +0.0765         +0.0833          1773          1909          1775          1923
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/double                  -0.2372         -0.2336          2155          1644          2157          1653
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/uint32_t                -0.3402         -0.3394          1689          1114          1691          1117
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/int32_t                 -0.3457         -0.3445          1705          1116          1706          1118
[scalarkvsort.*random_128 vs. simdkvsort.*random_128]/float                   -0.4488         -0.4485          2177          1200          2179          1201
OVERALL_GEOMEAN                                                               -0.2251         -0.2230             0             0             0             0

Benchmark                                                                      Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------------
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/uint64_t                -0.2675         -0.2674         22952         16813         22963         16822
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/int64_t                 -0.3494         -0.3493         23429         15243         23440         15253
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/double                  -0.7164         -0.7162         44117         12513         44131         12523
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/uint32_t                -0.6435         -0.6431         17177          6124         17184          6133
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/int32_t                 -0.6460         -0.6458         17605          6231         17612          6238
[scalarkvsort.*random_1k vs. simdkvsort.*random_1k]/float                   -0.8430         -0.8428         44325          6960         44333          6968
OVERALL_GEOMEAN                                                             -0.6273         -0.6271             0             0             0             0

Benchmark                                                                      Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------------
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/uint64_t                -0.8630         -0.8630     192462669      26358200     192446270      26357705
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/int64_t                 -0.8728         -0.8728     192637350      24496545     192630780      24496142
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/double                  -0.9052         -0.9052     217953698      20668767     217937330      20667636
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/uint32_t                -0.9384         -0.9384     168347341      10363963     168335643      10363599
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/int32_t                 -0.9362         -0.9362     170325919      10866820     170300695      10866190
[scalarkvsort.*random_1m vs. simdkvsort.*random_1m]/float                   -0.9425         -0.9425     196415775      11294391     196401933      11294226
OVERALL_GEOMEAN                                                             -0.9152         -0.9152             0             0             0             0
```

</details>

