### PR TITLE
Throw a compiler warning instead of error when built with just avx512f

### DIFF
--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -134,10 +134,10 @@ x86simdsortStatic::keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan)
     avx512_qsort_kv(key, val, size, hasnan);
 }
 
-#elif defined(__AVX512F__)
-#error "x86simdsort requires AVX512DQ and AVX512VL to be enabled in addition to AVX512F to use AVX512"
-
-#elif defined(__AVX2__) && !defined(__AVX512F__)
+#elif defined(__AVX2__)
+#if defined(__AVX512F__)
+#warning "Building x86simdsortStatic with AVX2 sort functions. AVX512 sorting additionally requires AVX512DQ and AVX512VL."
+#endif
 /* 32-bit and 64-bit dtypes vector definitions on AVX2 */
 #include "avx2-32bit-half.hpp"
 #include "avx2-32bit-qsort.hpp"

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -136,7 +136,8 @@ x86simdsortStatic::keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan)
 
 #elif defined(__AVX2__)
 #if defined(__AVX512F__)
-#warning "Building x86simdsortStatic with AVX2 sort functions. AVX512 sorting additionally requires AVX512DQ and AVX512VL."
+#warning \
+        "Building x86simdsortStatic with AVX2 sort functions. AVX512 sorting additionally requires AVX512DQ and AVX512VL."
 #endif
 /* 32-bit and 64-bit dtypes vector definitions on AVX2 */
 #include "avx2-32bit-half.hpp"


### PR DESCRIPTION
The error is a problem when building NumPy with baseline cpu feature of avx512f. 