### PR TITLE
Hide keyvalue_qsort symbols in shared library

### DIFF
--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -12,7 +12,7 @@ namespace avx512 {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
     // quickselect
     template <typename T>
@@ -46,7 +46,7 @@ namespace avx2 {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
     // quickselect
     template <typename T>
@@ -80,7 +80,7 @@ namespace scalar {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
     // quickselect
     template <typename T>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('x86-simd-sort', 'cpp',
-        version : '4.0.0',
+        version : '5.0.x',
         license : 'BSD 3-clause',
         default_options : ['cpp_std=c++17'])
 fs = import('fs')
@@ -40,7 +40,7 @@ libsimdsort = shared_library('x86simdsortcpp',
                              link_with : [libtargets],
                              gnu_symbol_visibility : 'inlineshidden',
                              install : true,
-                             soversion : 0,
+                             soversion : 1,
                             )
 
 pkg_mod = import('pkgconfig')


### PR DESCRIPTION
Introduced in 67c7534bfcb277368502f1d496a6c1075542b645