### PR TITLE
Adds support for kv-select, kv-partial sort, and descending order for all key-value functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ int32_t, double, uint64_t, int64_t]`
 
 ## Key-value sort routines on pairs of arrays
 ```cpp
-void x86simdsort::keyvalue_qsort(T1* key, T2* val, size_t size, bool hasnan);
+void x86simdsort::keyvalue_qsort(T1* key, T2* val, size_t size, bool hasnan, bool descending);
+void x86simdsort::keyvalue_select(T1* key, T2* val, size_t k, size_t size, bool hasnan, bool descending);
+void x86simdsort::keyvalue_partial_sort(T1* key, T2* val, size_t k, size_t size, bool hasnan, bool descending);
 ```
 Supported datatypes: `T1`, `T2` $\in$ `[float, uint32_t, int32_t, double,
 uint64_t, int64_t]` Note that keyvalue sort is not yet supported for 16-bit

--- a/benchmarks/bench-keyvalue.hpp
+++ b/benchmarks/bench-keyvalue.hpp
@@ -13,7 +13,8 @@ static void scalarkvsort(benchmark::State &state, Args &&...args)
     std::vector<T> key_bkp = key;
     // benchmark
     for (auto _ : state) {
-        xss::scalar::keyvalue_qsort(key.data(), val.data(), arrsize, false, false);
+        xss::scalar::keyvalue_qsort(
+                key.data(), val.data(), arrsize, false, false);
         state.PauseTiming();
         key = key_bkp;
         state.ResumeTiming();

--- a/benchmarks/bench-keyvalue.hpp
+++ b/benchmarks/bench-keyvalue.hpp
@@ -13,7 +13,7 @@ static void scalarkvsort(benchmark::State &state, Args &&...args)
     std::vector<T> key_bkp = key;
     // benchmark
     for (auto _ : state) {
-        xss::scalar::keyvalue_qsort(key.data(), val.data(), arrsize, false);
+        xss::scalar::keyvalue_qsort(key.data(), val.data(), arrsize, false, false);
         state.PauseTiming();
         key = key_bkp;
         state.ResumeTiming();

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -36,19 +36,19 @@
 
 #define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan) \
+    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan, descending); \
     }
     
 #define DEFINE_KEYVALUE_METHODS(type) \

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -34,37 +34,30 @@
         return x86simdsortStatic::argselect(arr, k, arrsize, hasnan); \
     }
 
-#define DEFINE_KEYVALUE_METHODS(type) \
+#define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type *key, uint64_t *val, size_t arrsize, bool hasnan) \
+    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan) \
     { \
         x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
-    void keyvalue_qsort(type *key, int64_t *val, size_t arrsize, bool hasnan) \
+    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan); \
     } \
     template <> \
-    void keyvalue_qsort(type *key, double *val, size_t arrsize, bool hasnan) \
+    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, uint32_t *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, int32_t *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, float *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan); \
     }
+    
+#define DEFINE_KEYVALUE_METHODS(type) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, uint64_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, int64_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, double) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, uint32_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, int32_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, float)
 
 namespace xss {
 namespace avx2 {

--- a/lib/x86simdsort-avx2.cpp
+++ b/lib/x86simdsort-avx2.cpp
@@ -36,21 +36,38 @@
 
 #define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_qsort(type1 *key, \
+                        type2 *val, \
+                        size_t arrsize, \
+                        bool hasnan, \
+                        bool descending) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_qsort( \
+                key, val, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_select(type1 *key, \
+                         type2 *val, \
+                         size_t k, \
+                         size_t arrsize, \
+                         bool hasnan, \
+                         bool descending) \
     { \
-        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_select( \
+                key, val, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_partial_sort(type1 *key, \
+                               type2 *val, \
+                               size_t k, \
+                               size_t arrsize, \
+                               bool hasnan, \
+                               bool descending) \
     { \
-        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_partial_sort( \
+                key, val, k, arrsize, hasnan, descending); \
     }
-    
+
 #define DEFINE_KEYVALUE_METHODS(type) \
     DEFINE_KEYVALUE_METHODS_BASE(type, uint64_t) \
     DEFINE_KEYVALUE_METHODS_BASE(type, int64_t) \

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -21,6 +21,10 @@ namespace avx512 {
                                  size_t arrsize,
                                  bool hasnan = false,
                                  bool descending = false);
+    // key-value select
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -28,6 +32,10 @@ namespace avx512 {
                                        size_t arrsize,
                                        bool hasnan = false,
                                        bool descending = false);
+    // key-value partial sort
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -55,6 +63,10 @@ namespace avx2 {
                                  size_t arrsize,
                                  bool hasnan = false,
                                  bool descending = false);
+    // key-value select
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -62,6 +74,10 @@ namespace avx2 {
                                        size_t arrsize,
                                        bool hasnan = false,
                                        bool descending = false);
+    // key-value partial sort
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -89,6 +105,10 @@ namespace scalar {
                                  size_t arrsize,
                                  bool hasnan = false,
                                  bool descending = false);
+    // key-value select
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -96,6 +116,10 @@ namespace scalar {
                                        size_t arrsize,
                                        bool hasnan = false,
                                        bool descending = false);
+    // key-value partial sort
+    template <typename T1, typename T2>
+    XSS_EXPORT_SYMBOL void
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -13,7 +13,7 @@ namespace avx512 {
     // key-value quicksort
     template <typename T1, typename T2>
     XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
+    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -24,7 +24,7 @@ namespace avx512 {
     // key-value select
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -35,7 +35,7 @@ namespace avx512 {
     // key-value partial sort
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -66,7 +66,7 @@ namespace avx2 {
     // key-value select
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -77,7 +77,7 @@ namespace avx2 {
     // key-value partial sort
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -97,7 +97,7 @@ namespace scalar {
     // key-value quicksort
     template <typename T1, typename T2>
     XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
+    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -108,7 +108,7 @@ namespace scalar {
     // key-value select
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -119,7 +119,7 @@ namespace scalar {
     // key-value partial sort
     template <typename T1, typename T2>
     XSS_EXPORT_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -23,7 +23,7 @@ namespace avx512 {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
@@ -34,7 +34,7 @@ namespace avx512 {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>
@@ -55,7 +55,7 @@ namespace avx2 {
     // key-value quicksort
     template <typename T1, typename T2>
     XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
+    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -65,7 +65,7 @@ namespace avx2 {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
@@ -76,7 +76,7 @@ namespace avx2 {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>
@@ -107,7 +107,7 @@ namespace scalar {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // partial sort
     template <typename T>
@@ -118,7 +118,7 @@ namespace scalar {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_EXPORT_SYMBOL void
+    XSS_HIDE_SYMBOL void
     keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
     // argsort
     template <typename T>

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -12,8 +12,11 @@ namespace avx512 {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
+                                        T2 *val,
+                                        size_t arrsize,
+                                        bool hasnan = false,
+                                        bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -23,8 +26,12 @@ namespace avx512 {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
+                                         T2 *val,
+                                         size_t k,
+                                         size_t arrsize,
+                                         bool hasnan = false,
+                                         bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -34,8 +41,12 @@ namespace avx512 {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
+                                               T2 *val,
+                                               size_t k,
+                                               size_t arrsize,
+                                               bool hasnan = false,
+                                               bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -54,8 +65,11 @@ namespace avx2 {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
+                                        T2 *val,
+                                        size_t arrsize,
+                                        bool hasnan = false,
+                                        bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -65,8 +79,12 @@ namespace avx2 {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
+                                         T2 *val,
+                                         size_t k,
+                                         size_t arrsize,
+                                         bool hasnan = false,
+                                         bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -76,8 +94,12 @@ namespace avx2 {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
+                                               T2 *val,
+                                               size_t k,
+                                               size_t arrsize,
+                                               bool hasnan = false,
+                                               bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
@@ -96,8 +118,11 @@ namespace scalar {
     qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
     // key-value quicksort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
+                                        T2 *val,
+                                        size_t arrsize,
+                                        bool hasnan = false,
+                                        bool descending = false);
     // quickselect
     template <typename T>
     XSS_HIDE_SYMBOL void qselect(T *arr,
@@ -107,8 +132,12 @@ namespace scalar {
                                  bool descending = false);
     // key-value select
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
+                                         T2 *val,
+                                         size_t k,
+                                         size_t arrsize,
+                                         bool hasnan = false,
+                                         bool descending = false);
     // partial sort
     template <typename T>
     XSS_HIDE_SYMBOL void partial_qsort(T *arr,
@@ -118,8 +147,12 @@ namespace scalar {
                                        bool descending = false);
     // key-value partial sort
     template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void
-    keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
+                                               T2 *val,
+                                               size_t k,
+                                               size_t arrsize,
+                                               bool hasnan = false,
+                                               bool descending = false);
     // argsort
     template <typename T>
     XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -100,30 +100,41 @@ namespace scalar {
         return arg;
     }
     template <typename T1, typename T2>
-    void keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan, bool descending)
+    void keyvalue_qsort(
+            T1 *key, T2 *val, size_t arrsize, bool hasnan, bool descending)
     {
         std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }
     template <typename T1, typename T2>
-    void keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan, bool descending)
+    void keyvalue_select(T1 *key,
+                         T2 *val,
+                         size_t k,
+                         size_t arrsize,
+                         bool hasnan,
+                         bool descending)
     {
         if (k == 0) return;
         // Note that this does a full partial sort, not just a select
         std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         //arg.resize(k);
-        
+
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }
     template <typename T1, typename T2>
-    void keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan, bool descending)
+    void keyvalue_partial_sort(T1 *key,
+                               T2 *val,
+                               size_t k,
+                               size_t arrsize,
+                               bool hasnan,
+                               bool descending)
     {
         if (k == 0) return;
         std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         //arg.resize(k);
-        
+
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -100,28 +100,28 @@ namespace scalar {
         return arg;
     }
     template <typename T1, typename T2>
-    void keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan)
+    void keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan, bool descending)
     {
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }
     template <typename T1, typename T2>
-    void keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan)
+    void keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan, bool descending)
     {
         if (k == 0) return;
         // Note that this does a full partial sort, not just a select
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         //arg.resize(k);
         
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }
     template <typename T1, typename T2>
-    void keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan)
+    void keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan, bool descending)
     {
         if (k == 0) return;
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
         //arg.resize(k);
         
         utils::apply_permutation_in_place(key, arg);

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -106,6 +106,27 @@ namespace scalar {
         utils::apply_permutation_in_place(key, arg);
         utils::apply_permutation_in_place(val, arg);
     }
+    template <typename T1, typename T2>
+    void keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan)
+    {
+        if (k == 0) return;
+        // Note that this does a full partial sort, not just a select
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
+        //arg.resize(k);
+        
+        utils::apply_permutation_in_place(key, arg);
+        utils::apply_permutation_in_place(val, arg);
+    }
+    template <typename T1, typename T2>
+    void keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan)
+    {
+        if (k == 0) return;
+        std::vector<size_t> arg = argsort(key, arrsize, hasnan, false);
+        //arg.resize(k);
+        
+        utils::apply_permutation_in_place(key, arg);
+        utils::apply_permutation_in_place(val, arg);
+    }
 
 } // namespace scalar
 } // namespace xss

--- a/lib/x86simdsort-scalar.h
+++ b/lib/x86simdsort-scalar.h
@@ -115,13 +115,9 @@ namespace scalar {
                          bool hasnan,
                          bool descending)
     {
-        if (k == 0) return;
-        // Note that this does a full partial sort, not just a select
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
-        //arg.resize(k);
-
-        utils::apply_permutation_in_place(key, arg);
-        utils::apply_permutation_in_place(val, arg);
+        // Note that this does a full kv-sort
+        UNUSED(k);
+        keyvalue_qsort(key, val, arrsize, hasnan, descending);
     }
     template <typename T1, typename T2>
     void keyvalue_partial_sort(T1 *key,
@@ -131,12 +127,9 @@ namespace scalar {
                                bool hasnan,
                                bool descending)
     {
-        if (k == 0) return;
-        std::vector<size_t> arg = argsort(key, arrsize, hasnan, descending);
-        //arg.resize(k);
-
-        utils::apply_permutation_in_place(key, arg);
-        utils::apply_permutation_in_place(val, arg);
+        // Note that this does a full kv-sort
+        UNUSED(k);
+        keyvalue_qsort(key, val, arrsize, hasnan, descending);
     }
 
 } // namespace scalar

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -36,19 +36,19 @@
 
 #define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan) \
+    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
-        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan, descending); \
     }
     
 #define DEFINE_KEYVALUE_METHODS(type) \

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -36,21 +36,38 @@
 
 #define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_qsort(type1 *key, \
+                        type2 *val, \
+                        size_t arrsize, \
+                        bool hasnan, \
+                        bool descending) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_qsort( \
+                key, val, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_select(type1 *key, \
+                         type2 *val, \
+                         size_t k, \
+                         size_t arrsize, \
+                         bool hasnan, \
+                         bool descending) \
     { \
-        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_select( \
+                key, val, k, arrsize, hasnan, descending); \
     } \
     template <> \
-    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_partial_sort(type1 *key, \
+                               type2 *val, \
+                               size_t k, \
+                               size_t arrsize, \
+                               bool hasnan, \
+                               bool descending) \
     { \
-        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan, descending); \
+        x86simdsortStatic::keyvalue_partial_sort( \
+                key, val, k, arrsize, hasnan, descending); \
     }
-    
+
 #define DEFINE_KEYVALUE_METHODS(type) \
     DEFINE_KEYVALUE_METHODS_BASE(type, uint64_t) \
     DEFINE_KEYVALUE_METHODS_BASE(type, int64_t) \

--- a/lib/x86simdsort-skx.cpp
+++ b/lib/x86simdsort-skx.cpp
@@ -34,37 +34,30 @@
         return x86simdsortStatic::argselect(arr, k, arrsize, hasnan); \
     }
 
-#define DEFINE_KEYVALUE_METHODS(type) \
+#define DEFINE_KEYVALUE_METHODS_BASE(type1, type2) \
     template <> \
-    void keyvalue_qsort(type *key, uint64_t *val, size_t arrsize, bool hasnan) \
+    void keyvalue_qsort(type1 *key, type2 *val, size_t arrsize, bool hasnan) \
     { \
         x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
     } \
     template <> \
-    void keyvalue_qsort(type *key, int64_t *val, size_t arrsize, bool hasnan) \
+    void keyvalue_select(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_select(key, val, k, arrsize, hasnan); \
     } \
     template <> \
-    void keyvalue_qsort(type *key, double *val, size_t arrsize, bool hasnan) \
+    void keyvalue_partial_sort(type1 *key, type2 *val, size_t k, size_t arrsize, bool hasnan) \
     { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, uint32_t *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, int32_t *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
-    } \
-    template <> \
-    void keyvalue_qsort(type *key, float *val, size_t arrsize, bool hasnan) \
-    { \
-        x86simdsortStatic::keyvalue_qsort(key, val, arrsize, hasnan); \
+        x86simdsortStatic::keyvalue_partial_sort(key, val, k, arrsize, hasnan); \
     }
+    
+#define DEFINE_KEYVALUE_METHODS(type) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, uint64_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, int64_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, double) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, uint32_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, int32_t) \
+    DEFINE_KEYVALUE_METHODS_BASE(type, float)
 
 namespace xss {
 namespace avx512 {

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -134,7 +134,11 @@ namespace x86simdsort {
             TYPE1 *, TYPE2 *, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_qsort(TYPE1 *key, TYPE2 *val, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_qsort(TYPE1 *key, \
+                        TYPE2 *val, \
+                        size_t arrsize, \
+                        bool hasnan, \
+                        bool descending) \
     { \
         (CAT(CAT(*internal_kv_qsort_, TYPE1), TYPE2))( \
                 key, val, arrsize, hasnan, descending); \
@@ -160,12 +164,17 @@ namespace x86simdsort {
                 return; \
             } \
         } \
-    }\
+    } \
     static void(CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
             TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_select(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_select(TYPE1 *key, \
+                         TYPE2 *val, \
+                         size_t k, \
+                         size_t arrsize, \
+                         bool hasnan, \
+                         bool descending) \
     { \
         (CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
                 key, val, k, arrsize, hasnan, descending); \
@@ -196,7 +205,12 @@ namespace x86simdsort {
             TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_partial_sort(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
+    void keyvalue_partial_sort(TYPE1 *key, \
+                               TYPE2 *val, \
+                               size_t k, \
+                               size_t arrsize, \
+                               bool hasnan, \
+                               bool descending) \
     { \
         (CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
                 key, val, k, arrsize, hasnan, descending); \

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -160,6 +160,68 @@ namespace x86simdsort {
                 return; \
             } \
         } \
+    }\
+    static void(CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool) \
+            = NULL; \
+    template <> \
+    void keyvalue_select(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan) \
+    { \
+        (CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
+                key, val, k, arrsize, hasnan); \
+    } \
+    static __attribute__((constructor)) void CAT( \
+            CAT(resolve_keyvalue_select_, TYPE1), TYPE2)(void) \
+    { \
+        CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
+                = &xss::scalar::keyvalue_select<TYPE1, TYPE2>; \
+        __builtin_cpu_init(); \
+        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
+        if constexpr (dispatch_requested("avx512", ISA)) { \
+            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
+                CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
+                        = &xss::avx512::keyvalue_select<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
+        if constexpr (dispatch_requested("avx2", ISA)) { \
+            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
+                CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
+                        = &xss::avx2::keyvalue_select<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
+    } \
+    static void(CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool) \
+            = NULL; \
+    template <> \
+    void keyvalue_partial_sort(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan) \
+    { \
+        (CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
+                key, val, k, arrsize, hasnan); \
+    } \
+    static __attribute__((constructor)) void CAT( \
+            CAT(resolve_keyvalue_partial_sort_, TYPE1), TYPE2)(void) \
+    { \
+        CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
+                = &xss::scalar::keyvalue_partial_sort<TYPE1, TYPE2>; \
+        __builtin_cpu_init(); \
+        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
+        if constexpr (dispatch_requested("avx512", ISA)) { \
+            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
+                CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
+                        = &xss::avx512::keyvalue_partial_sort<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
+        if constexpr (dispatch_requested("avx2", ISA)) { \
+            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
+                CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
+                        = &xss::avx2::keyvalue_partial_sort<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
     }
 
 #define ISA_LIST(...) \

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -129,115 +129,6 @@ namespace x86simdsort {
         } \
     }
 
-#define DISPATCH_KEYVALUE_SORT(TYPE1, TYPE2, ISA) \
-    static void(CAT(CAT(*internal_kv_qsort_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, bool, bool) \
-            = NULL; \
-    template <> \
-    void keyvalue_qsort(TYPE1 *key, \
-                        TYPE2 *val, \
-                        size_t arrsize, \
-                        bool hasnan, \
-                        bool descending) \
-    { \
-        (CAT(CAT(*internal_kv_qsort_, TYPE1), TYPE2))( \
-                key, val, arrsize, hasnan, descending); \
-    } \
-    static __attribute__((constructor)) void CAT( \
-            CAT(resolve_keyvalue_qsort_, TYPE1), TYPE2)(void) \
-    { \
-        CAT(CAT(internal_kv_qsort_, TYPE1), TYPE2) \
-                = &xss::scalar::keyvalue_qsort<TYPE1, TYPE2>; \
-        __builtin_cpu_init(); \
-        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
-        if constexpr (dispatch_requested("avx512", ISA)) { \
-            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_qsort_, TYPE1), TYPE2) \
-                        = &xss::avx512::keyvalue_qsort<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-        if constexpr (dispatch_requested("avx2", ISA)) { \
-            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_qsort_, TYPE1), TYPE2) \
-                        = &xss::avx2::keyvalue_qsort<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-    } \
-    static void(CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
-            = NULL; \
-    template <> \
-    void keyvalue_select(TYPE1 *key, \
-                         TYPE2 *val, \
-                         size_t k, \
-                         size_t arrsize, \
-                         bool hasnan, \
-                         bool descending) \
-    { \
-        (CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
-                key, val, k, arrsize, hasnan, descending); \
-    } \
-    static __attribute__((constructor)) void CAT( \
-            CAT(resolve_keyvalue_select_, TYPE1), TYPE2)(void) \
-    { \
-        CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
-                = &xss::scalar::keyvalue_select<TYPE1, TYPE2>; \
-        __builtin_cpu_init(); \
-        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
-        if constexpr (dispatch_requested("avx512", ISA)) { \
-            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
-                        = &xss::avx512::keyvalue_select<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-        if constexpr (dispatch_requested("avx2", ISA)) { \
-            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_select_, TYPE1), TYPE2) \
-                        = &xss::avx2::keyvalue_select<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-    } \
-    static void(CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
-            = NULL; \
-    template <> \
-    void keyvalue_partial_sort(TYPE1 *key, \
-                               TYPE2 *val, \
-                               size_t k, \
-                               size_t arrsize, \
-                               bool hasnan, \
-                               bool descending) \
-    { \
-        (CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
-                key, val, k, arrsize, hasnan, descending); \
-    } \
-    static __attribute__((constructor)) void CAT( \
-            CAT(resolve_keyvalue_partial_sort_, TYPE1), TYPE2)(void) \
-    { \
-        CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
-                = &xss::scalar::keyvalue_partial_sort<TYPE1, TYPE2>; \
-        __builtin_cpu_init(); \
-        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
-        if constexpr (dispatch_requested("avx512", ISA)) { \
-            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
-                        = &xss::avx512::keyvalue_partial_sort<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-        if constexpr (dispatch_requested("avx2", ISA)) { \
-            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
-                CAT(CAT(internal_kv_partial_sort_, TYPE1), TYPE2) \
-                        = &xss::avx2::keyvalue_partial_sort<TYPE1, TYPE2>; \
-                return; \
-            } \
-        } \
-    }
-
 #define ISA_LIST(...) \
     std::initializer_list<std::string_view> \
     { \
@@ -282,6 +173,80 @@ DISPATCH_ALL(argselect,
              (ISA_LIST("none")),
              (ISA_LIST("avx512_skx", "avx2")),
              (ISA_LIST("avx512_skx", "avx2")))
+
+/* Key-Value methods */
+#define DECLARE_ALL_KEYVALUE_METHODS(TYPE1, TYPE2) \
+    static void(CAT(CAT(*internal_keyvalue_qsort_, TYPE1), TYPE2))( \
+            TYPE1 *, TYPE2 *, size_t, bool, bool) \
+            = NULL; \
+    static void(CAT(CAT(*internal_keyvalue_select_, TYPE1), TYPE2))( \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
+            = NULL; \
+    static void(CAT(CAT(*internal_keyvalue_partial_sort_, TYPE1), TYPE2))( \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
+            = NULL; \
+    template <> \
+    void keyvalue_qsort(TYPE1 *key, \
+                        TYPE2 *val, \
+                        size_t arrsize, \
+                        bool hasnan, \
+                        bool descending) \
+    { \
+        (CAT(CAT(*internal_keyvalue_qsort_, TYPE1), TYPE2))( \
+                key, val, arrsize, hasnan, descending); \
+    } \
+    template <> \
+    void keyvalue_select(TYPE1 *key, \
+                         TYPE2 *val, \
+                         size_t k, \
+                         size_t arrsize, \
+                         bool hasnan, \
+                         bool descending) \
+    { \
+        (CAT(CAT(*internal_keyvalue_select_, TYPE1), TYPE2))( \
+                key, val, k, arrsize, hasnan, descending); \
+    } \
+    template <> \
+    void keyvalue_partial_sort(TYPE1 *key, \
+                               TYPE2 *val, \
+                               size_t k, \
+                               size_t arrsize, \
+                               bool hasnan, \
+                               bool descending) \
+    { \
+        (CAT(CAT(*internal_keyvalue_partial_sort_, TYPE1), TYPE2))( \
+                key, val, k, arrsize, hasnan, descending); \
+    }
+
+#define DISPATCH_KV_FUNC(func, TYPE1, TYPE2, ISA) \
+    static __attribute__((constructor)) void CAT( \
+            CAT(CAT(CAT(resolve_, func), _), TYPE1), TYPE2)(void) \
+    { \
+        CAT(CAT(CAT(CAT(internal_, func), _), TYPE1), TYPE2) \
+                = &xss::scalar::func<TYPE1, TYPE2>; \
+        __builtin_cpu_init(); \
+        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
+        if constexpr (dispatch_requested("avx512", ISA)) { \
+            if (preferred_cpu.find("avx512") != std::string_view::npos) { \
+                CAT(CAT(CAT(CAT(internal_, func), _), TYPE1), TYPE2) \
+                        = &xss::avx512::func<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
+        if constexpr (dispatch_requested("avx2", ISA)) { \
+            if (preferred_cpu.find("avx2") != std::string_view::npos) { \
+                CAT(CAT(CAT(CAT(internal_, func), _), TYPE1), TYPE2) \
+                        = &xss::avx2::func<TYPE1, TYPE2>; \
+                return; \
+            } \
+        } \
+    }
+
+#define DISPATCH_KEYVALUE_SORT(TYPE1, TYPE2, ISA) \
+    DECLARE_ALL_KEYVALUE_METHODS(TYPE1, TYPE2) \
+    DISPATCH_KV_FUNC(keyvalue_qsort, TYPE1, TYPE2, ISA) \
+    DISPATCH_KV_FUNC(keyvalue_select, TYPE1, TYPE2, ISA) \
+    DISPATCH_KV_FUNC(keyvalue_partial_sort, TYPE1, TYPE2, ISA)
 
 #define DISPATCH_KEYVALUE_SORT_FORTYPE(type) \
     DISPATCH_KEYVALUE_SORT(type, uint64_t, (ISA_LIST("avx512_skx", "avx2"))) \

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -131,13 +131,13 @@ namespace x86simdsort {
 
 #define DISPATCH_KEYVALUE_SORT(TYPE1, TYPE2, ISA) \
     static void(CAT(CAT(*internal_kv_qsort_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, bool) \
+            TYPE1 *, TYPE2 *, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_qsort(TYPE1 *key, TYPE2 *val, size_t arrsize, bool hasnan) \
+    void keyvalue_qsort(TYPE1 *key, TYPE2 *val, size_t arrsize, bool hasnan, bool descending) \
     { \
         (CAT(CAT(*internal_kv_qsort_, TYPE1), TYPE2))( \
-                key, val, arrsize, hasnan); \
+                key, val, arrsize, hasnan, descending); \
     } \
     static __attribute__((constructor)) void CAT( \
             CAT(resolve_keyvalue_qsort_, TYPE1), TYPE2)(void) \
@@ -162,13 +162,13 @@ namespace x86simdsort {
         } \
     }\
     static void(CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, size_t, bool) \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_select(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_select(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
         (CAT(CAT(*internal_kv_select_, TYPE1), TYPE2))( \
-                key, val, k, arrsize, hasnan); \
+                key, val, k, arrsize, hasnan, descending); \
     } \
     static __attribute__((constructor)) void CAT( \
             CAT(resolve_keyvalue_select_, TYPE1), TYPE2)(void) \
@@ -193,13 +193,13 @@ namespace x86simdsort {
         } \
     } \
     static void(CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
-            TYPE1 *, TYPE2 *, size_t, size_t, bool) \
+            TYPE1 *, TYPE2 *, size_t, size_t, bool, bool) \
             = NULL; \
     template <> \
-    void keyvalue_partial_sort(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan) \
+    void keyvalue_partial_sort(TYPE1 *key, TYPE2 *val, size_t k, size_t arrsize, bool hasnan, bool descending) \
     { \
         (CAT(CAT(*internal_kv_partial_sort_, TYPE1), TYPE2))( \
-                key, val, k, arrsize, hasnan); \
+                key, val, k, arrsize, hasnan, descending); \
     } \
     static __attribute__((constructor)) void CAT( \
             CAT(resolve_keyvalue_partial_sort_, TYPE1), TYPE2)(void) \

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -48,6 +48,16 @@ template <typename T1, typename T2>
 XSS_EXPORT_SYMBOL void
 keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
 
+// keyvalue select
+template <typename T1, typename T2>
+XSS_EXPORT_SYMBOL void
+keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+
+// keyvalue partial sort
+template <typename T1, typename T2>
+XSS_EXPORT_SYMBOL void
+keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+
 // sort an object
 template <typename T, typename Func>
 XSS_EXPORT_SYMBOL void object_qsort(T *arr, uint32_t arrsize, Func key_func)

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -45,18 +45,29 @@ argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
 
 // keyvalue sort
 template <typename T1, typename T2>
-XSS_EXPORT_SYMBOL void
-keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
+XSS_EXPORT_SYMBOL void keyvalue_qsort(T1 *key,
+                                      T2 *val,
+                                      size_t arrsize,
+                                      bool hasnan = false,
+                                      bool descending = false);
 
 // keyvalue select
 template <typename T1, typename T2>
-XSS_EXPORT_SYMBOL void
-keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+XSS_EXPORT_SYMBOL void keyvalue_select(T1 *key,
+                                       T2 *val,
+                                       size_t k,
+                                       size_t arrsize,
+                                       bool hasnan = false,
+                                       bool descending = false);
 
 // keyvalue partial sort
 template <typename T1, typename T2>
-XSS_EXPORT_SYMBOL void
-keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+XSS_EXPORT_SYMBOL void keyvalue_partial_sort(T1 *key,
+                                             T2 *val,
+                                             size_t k,
+                                             size_t arrsize,
+                                             bool hasnan = false,
+                                             bool descending = false);
 
 // sort an object
 template <typename T, typename Func>

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -46,17 +46,17 @@ argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
 // keyvalue sort
 template <typename T1, typename T2>
 XSS_EXPORT_SYMBOL void
-keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false);
+keyvalue_qsort(T1 *key, T2 *val, size_t arrsize, bool hasnan = false, bool descending = false);
 
 // keyvalue select
 template <typename T1, typename T2>
 XSS_EXPORT_SYMBOL void
-keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+keyvalue_select(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
 
 // keyvalue partial sort
 template <typename T1, typename T2>
 XSS_EXPORT_SYMBOL void
-keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false);
+keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
 
 // sort an object
 template <typename T, typename Func>

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -46,16 +46,27 @@ void X86_SIMD_SORT_FINLINE
 argselect(T *arr, size_t *arg, size_t k, size_t size, bool hasnan = false);
 
 template <typename T1, typename T2>
-X86_SIMD_SORT_FINLINE void
-keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false, bool descending = false);
+X86_SIMD_SORT_FINLINE void keyvalue_qsort(T1 *key,
+                                          T2 *val,
+                                          size_t size,
+                                          bool hasnan = false,
+                                          bool descending = false);
 
 template <typename T1, typename T2>
-X86_SIMD_SORT_FINLINE void
-keyvalue_select(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false, bool descending = false);
+X86_SIMD_SORT_FINLINE void keyvalue_select(T1 *key,
+                                           T2 *val,
+                                           size_t k,
+                                           size_t size,
+                                           bool hasnan = false,
+                                           bool descending = false);
 
 template <typename T1, typename T2>
-X86_SIMD_SORT_FINLINE void
-keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false, bool descending = false);
+X86_SIMD_SORT_FINLINE void keyvalue_partial_sort(T1 *key,
+                                                 T2 *val,
+                                                 size_t k,
+                                                 size_t size,
+                                                 bool hasnan = false,
+                                                 bool descending = false);
 
 } // namespace x86simdsortStatic
 
@@ -117,13 +128,23 @@ keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = fal
     } \
     template <typename T1, typename T2> \
     X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_select( \
-            T1 *key, T2 *val, size_t k, size_t size, bool hasnan, bool descending) \
+            T1 *key, \
+            T2 *val, \
+            size_t k, \
+            size_t size, \
+            bool hasnan, \
+            bool descending) \
     { \
         ISA##_select_kv(key, val, k, size, hasnan, descending); \
     } \
     template <typename T1, typename T2> \
     X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_partial_sort( \
-            T1 *key, T2 *val, size_t k, size_t size, bool hasnan, bool descending) \
+            T1 *key, \
+            T2 *val, \
+            size_t k, \
+            size_t size, \
+            bool hasnan, \
+            bool descending) \
     { \
         ISA##_partial_sort_kv(key, val, k, size, hasnan, descending); \
     }

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -49,6 +49,14 @@ template <typename T1, typename T2>
 X86_SIMD_SORT_FINLINE void
 keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
 
+template <typename T1, typename T2>
+X86_SIMD_SORT_FINLINE void
+keyvalue_select(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false);
+
+template <typename T1, typename T2>
+X86_SIMD_SORT_FINLINE void
+keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false);
+
 } // namespace x86simdsortStatic
 
 #define XSS_METHODS(ISA) \
@@ -106,6 +114,18 @@ keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
             T1 *key, T2 *val, size_t size, bool hasnan) \
     { \
         ISA##_qsort_kv(key, val, size, hasnan); \
+    } \
+    template <typename T1, typename T2> \
+    X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_select( \
+            T1 *key, T2 *val, size_t k, size_t size, bool hasnan) \
+    { \
+        ISA##_select_kv(key, val, k, size, hasnan); \
+    } \
+    template <typename T1, typename T2> \
+    X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_partial_sort( \
+            T1 *key, T2 *val, size_t k, size_t size, bool hasnan) \
+    { \
+        ISA##_partial_sort_kv(key, val, k, size, hasnan); \
     }
 
 /*

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -47,15 +47,15 @@ argselect(T *arr, size_t *arg, size_t k, size_t size, bool hasnan = false);
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_FINLINE void
-keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false);
+keyvalue_qsort(T1 *key, T2 *val, size_t size, bool hasnan = false, bool descending = false);
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_FINLINE void
-keyvalue_select(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false);
+keyvalue_select(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false, bool descending = false);
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_FINLINE void
-keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false);
+keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = false, bool descending = false);
 
 } // namespace x86simdsortStatic
 
@@ -111,21 +111,21 @@ keyvalue_partial_sort(T1 *key, T2 *val, size_t k, size_t size, bool hasnan = fal
     } \
     template <typename T1, typename T2> \
     X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_qsort( \
-            T1 *key, T2 *val, size_t size, bool hasnan) \
+            T1 *key, T2 *val, size_t size, bool hasnan, bool descending) \
     { \
-        ISA##_qsort_kv(key, val, size, hasnan); \
+        ISA##_qsort_kv(key, val, size, hasnan, descending); \
     } \
     template <typename T1, typename T2> \
     X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_select( \
-            T1 *key, T2 *val, size_t k, size_t size, bool hasnan) \
+            T1 *key, T2 *val, size_t k, size_t size, bool hasnan, bool descending) \
     { \
-        ISA##_select_kv(key, val, k, size, hasnan); \
+        ISA##_select_kv(key, val, k, size, hasnan, descending); \
     } \
     template <typename T1, typename T2> \
     X86_SIMD_SORT_FINLINE void x86simdsortStatic::keyvalue_partial_sort( \
-            T1 *key, T2 *val, size_t k, size_t size, bool hasnan) \
+            T1 *key, T2 *val, size_t k, size_t size, bool hasnan, bool descending) \
     { \
-        ISA##_partial_sort_kv(key, val, k, size, hasnan); \
+        ISA##_partial_sort_kv(key, val, k, size, hasnan, descending); \
     }
 
 /*

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -435,6 +435,7 @@ X86_SIMD_SORT_INLINE void kvselect_(type1_t *keys,
     type1_t biggest = vtype1::type_min();
     arrsize_t pivot_index = kvpartition_unrolled<vtype1, vtype2, 4>(
             keys, indexes, left, right + 1, pivot, &smallest, &biggest);
+    
     if ((pivot != smallest) && (pos < pivot_index)) {
         kvselect_<vtype1, vtype2>(
                 keys, indexes, pos, left, pivot_index - 1, max_iters - 1);
@@ -452,7 +453,7 @@ template <typename T1,
           template <typename...>
           typename half_vector>
 X86_SIMD_SORT_INLINE void
-xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan)
+xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan, bool descending)
 {
     using keytype =
             typename std::conditional<sizeof(T1) != sizeof(T2)
@@ -484,14 +485,20 @@ xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan)
         else {
             UNUSED(hasnan);
         }
+        
         kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters);
         replace_inf_with_nan(keys, arrsize, nan_count);
+        
+        if (descending) {
+            std::reverse(keys, keys + arrsize);
+            std::reverse(indexes, indexes + arrsize);
+        }
     }
 }
 
 template <typename T1, typename T2, template <typename...> typename full_vector, template <typename...> typename half_vector>
 X86_SIMD_SORT_INLINE void
-xss_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+xss_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan, bool descending)
 {
     using keytype =
             typename std::conditional<sizeof(T1) != sizeof(T2)
@@ -513,6 +520,10 @@ xss_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan
 #endif // XSS_TEST_KEYVALUE_BASE_CASE
 
     if (minarrsize) {
+        if (descending){
+            k = arrsize - 1 - k;
+        }
+        
         if constexpr (std::is_floating_point_v<T1>) {
             arrsize_t nan_count = 0;
             if (UNLIKELY(hasnan)) {
@@ -526,63 +537,68 @@ xss_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan
             UNUSED(hasnan);
             kvselect_<keytype, valtype>(keys, indexes, k, 0, arrsize - 1, maxiters);
         }
+        
+        if (descending) {
+            std::reverse(keys, keys + arrsize);
+            std::reverse(indexes, indexes + arrsize);
+        }
     }
 }
 
 template <typename T1, typename T2, template <typename...> typename full_vector, template <typename...> typename half_vector>
 X86_SIMD_SORT_INLINE void
-xss_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+xss_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan, bool descending)
 {
     if (k == 0) return;
-    xss_select_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, arrsize, hasnan);
-    xss_qsort_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, hasnan);
+    xss_select_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, arrsize, hasnan, descending);
+    xss_qsort_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx512_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
+avx512_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_qsort_kv<T1, T2, zmm_vector, ymm_vector>(
-            keys, indexes, arrsize, hasnan);
+            keys, indexes, arrsize, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx2_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
+avx2_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_qsort_kv<T1, T2, avx2_vector, avx2_half_vector>(
-            keys, indexes, arrsize, hasnan);
+            keys, indexes, arrsize, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx512_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+avx512_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_select_kv<T1, T2, zmm_vector, ymm_vector>(
-            keys, indexes, k, arrsize, hasnan);
+            keys, indexes, k, arrsize, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx2_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+avx2_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_select_kv<T1, T2, avx2_vector, avx2_half_vector>(
-            keys, indexes, k, arrsize, hasnan);
+            keys, indexes, k, arrsize, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx512_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+avx512_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_partial_sort_kv<T1, T2, zmm_vector, ymm_vector>(
-            keys, indexes, k, arrsize, hasnan);
+            keys, indexes, k, arrsize, hasnan, descending);
 }
 
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
-avx2_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+avx2_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false, bool descending = false)
 {
     xss_partial_sort_kv<T1, T2, avx2_vector, avx2_half_vector>(
-            keys, indexes, k, arrsize, hasnan);
+            keys, indexes, k, arrsize, hasnan, descending);
 }
 #endif // AVX512_QSORT_64BIT_KV

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -401,6 +401,50 @@ X86_SIMD_SORT_INLINE void kvsort_(type1_t *keys,
     }
 }
 
+template <typename vtype1,
+          typename vtype2,
+          typename type1_t = typename vtype1::type_t,
+          typename type2_t = typename vtype2::type_t>
+X86_SIMD_SORT_INLINE void kvselect_(type1_t *keys,
+                                  type2_t *indexes,
+                                  arrsize_t pos,
+                                  arrsize_t left,
+                                  arrsize_t right,
+                                  int max_iters)
+{
+    /*
+     * Resort to std::sort if quicksort isnt making any progress
+     */
+    if (max_iters <= 0) {
+        heap_sort<vtype1, vtype2>(
+                keys + left, indexes + left, right - left + 1);
+        return;
+    }
+    /*
+     * Base case: use bitonic networks to sort arrays <= 128
+     */
+    if (right + 1 - left <= 128) {
+
+        kvsort_n<vtype1, vtype2, 128>(
+                keys + left, indexes + left, (int32_t)(right + 1 - left));
+        return;
+    }
+
+    type1_t pivot = get_pivot_blocks<vtype1>(keys, left, right);
+    type1_t smallest = vtype1::type_max();
+    type1_t biggest = vtype1::type_min();
+    arrsize_t pivot_index = kvpartition_unrolled<vtype1, vtype2, 4>(
+            keys, indexes, left, right + 1, pivot, &smallest, &biggest);
+    if ((pivot != smallest) && (pos < pivot_index)) {
+        kvselect_<vtype1, vtype2>(
+                keys, indexes, pos, left, pivot_index - 1, max_iters - 1);
+    }
+    else if ((pivot != biggest) && (pos >= pivot_index)) {
+        kvselect_<vtype1, vtype2>(
+                keys, indexes, pos, pivot_index, right, max_iters - 1);
+    }
+}
+
 template <typename T1,
           typename T2,
           template <typename...>
@@ -445,6 +489,55 @@ xss_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan)
     }
 }
 
+template <typename T1, typename T2, template <typename...> typename full_vector, template <typename...> typename half_vector>
+X86_SIMD_SORT_INLINE void
+xss_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    using keytype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T1) == sizeof(int32_t),
+                                      half_vector<T1>,
+                                      full_vector<T1>>::type;
+    using valtype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T2) == sizeof(int32_t),
+                                      half_vector<T2>,
+                                      full_vector<T2>>::type;
+
+#ifdef XSS_TEST_KEYVALUE_BASE_CASE
+    int maxiters = -1;
+    bool minarrsize = true;
+#else
+    int maxiters = 2 * log2(arrsize);
+    bool minarrsize = arrsize > 1 ? true : false;
+#endif // XSS_TEST_KEYVALUE_BASE_CASE
+
+    if (minarrsize) {
+        if constexpr (std::is_floating_point_v<T1>) {
+            arrsize_t nan_count = 0;
+            if (UNLIKELY(hasnan)) {
+                nan_count
+                        = replace_nan_with_inf<full_vector<T1>>(keys, arrsize);
+            }
+            kvselect_<keytype, valtype>(keys, indexes, k, 0, arrsize - 1, maxiters);
+            replace_inf_with_nan(keys, arrsize, nan_count);
+        }
+        else {
+            UNUSED(hasnan);
+            kvselect_<keytype, valtype>(keys, indexes, k, 0, arrsize - 1, maxiters);
+        }
+    }
+}
+
+template <typename T1, typename T2, template <typename...> typename full_vector, template <typename...> typename half_vector>
+X86_SIMD_SORT_INLINE void
+xss_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    if (k == 0) return;
+    xss_select_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, arrsize, hasnan);
+    xss_qsort_kv<T1, T2, full_vector, half_vector>(keys, indexes, k - 1, hasnan);
+}
+
 template <typename T1, typename T2>
 X86_SIMD_SORT_INLINE void
 avx512_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
@@ -459,5 +552,37 @@ avx2_qsort_kv(T1 *keys, T2 *indexes, arrsize_t arrsize, bool hasnan = false)
 {
     xss_qsort_kv<T1, T2, avx2_vector, avx2_half_vector>(
             keys, indexes, arrsize, hasnan);
+}
+
+template <typename T1, typename T2>
+X86_SIMD_SORT_INLINE void
+avx512_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    xss_select_kv<T1, T2, zmm_vector, ymm_vector>(
+            keys, indexes, k, arrsize, hasnan);
+}
+
+template <typename T1, typename T2>
+X86_SIMD_SORT_INLINE void
+avx2_select_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    xss_select_kv<T1, T2, avx2_vector, avx2_half_vector>(
+            keys, indexes, k, arrsize, hasnan);
+}
+
+template <typename T1, typename T2>
+X86_SIMD_SORT_INLINE void
+avx512_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    xss_partial_sort_kv<T1, T2, zmm_vector, ymm_vector>(
+            keys, indexes, k, arrsize, hasnan);
+}
+
+template <typename T1, typename T2>
+X86_SIMD_SORT_INLINE void
+avx2_partial_sort_kv(T1 *keys, T2 *indexes, arrsize_t k, arrsize_t arrsize, bool hasnan = false)
+{
+    xss_partial_sort_kv<T1, T2, avx2_vector, avx2_half_vector>(
+            keys, indexes, k, arrsize, hasnan);
 }
 #endif // AVX512_QSORT_64BIT_KV

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -672,6 +672,7 @@ template <typename vtype, typename T, bool descending = false>
 X86_SIMD_SORT_INLINE void
 xss_partial_qsort(T *arr, arrsize_t k, arrsize_t arrsize, bool hasnan)
 {
+    if (k == 0) return;
     xss_qselect<vtype, T, descending>(arr, k - 1, arrsize, hasnan);
     xss_qsort<vtype, T, descending>(arr, k - 1, hasnan);
 }

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -369,80 +369,13 @@ TYPED_TEST_P(simdkvsort, test_kvpartial_sort_descending)
     }
 }
 
-TYPED_TEST_P(simdkvsort, test_validator)
-{
-    // Tests a few edge cases to verify the tests are working correctly and identifying it as functional
-    using T1 = typename std::tuple_element<0, decltype(TypeParam())>::type;
-    using T2 = typename std::tuple_element<1, decltype(TypeParam())>::type;
-
-    bool is_kv_equivalent;
-
-    std::vector<T1> key = {0, 0, 1, 1};
-    std::vector<T2> val = {1, 2, 3, 4};
-    std::vector<T1> key_bckp = key;
-    std::vector<T2> val_bckp = val;
-
-    // Duplicate keys, but otherwise exactly identical
-    is_kv_equivalent = is_kv_sorted<T1, T2>(key.data(),
-                                            val.data(),
-                                            key_bckp.data(),
-                                            val_bckp.data(),
-                                            key.size());
-    ASSERT_EQ(is_kv_equivalent, true);
-
-    val = {2, 1, 4, 3};
-
-    // Now values are backwards, but this is still fine
-    is_kv_equivalent = is_kv_sorted<T1, T2>(key.data(),
-                                            val.data(),
-                                            key_bckp.data(),
-                                            val_bckp.data(),
-                                            key.size());
-    ASSERT_EQ(is_kv_equivalent, true);
-
-    val = {1, 3, 2, 4};
-
-    // Now values are mixed up, should fail
-    is_kv_equivalent = is_kv_sorted<T1, T2>(key.data(),
-                                            val.data(),
-                                            key_bckp.data(),
-                                            val_bckp.data(),
-                                            key.size());
-    ASSERT_EQ(is_kv_equivalent, false);
-
-    val = {1, 2, 3, 4};
-    key = {0, 0, 0, 0};
-
-    // Now keys are messed up, should fail
-    is_kv_equivalent = is_kv_sorted<T1, T2>(key.data(),
-                                            val.data(),
-                                            key_bckp.data(),
-                                            val_bckp.data(),
-                                            key.size());
-    ASSERT_EQ(is_kv_equivalent, false);
-
-    key = {0, 0, 0, 0, 0, 0};
-    key_bckp = key;
-    val_bckp = {1, 2, 3, 4, 5, 6};
-    val = {4, 3, 1, 6, 5, 2};
-
-    // All keys identical, simply reordered values
-    is_kv_equivalent = is_kv_sorted<T1, T2>(key.data(),
-                                            val.data(),
-                                            key_bckp.data(),
-                                            val_bckp.data(),
-                                            key.size());
-    ASSERT_EQ(is_kv_equivalent, true);
-}
-
 REGISTER_TYPED_TEST_SUITE_P(simdkvsort,
                             test_kvsort_ascending,
                             test_kvsort_descending,
                             test_kvselect_ascending,
                             test_kvselect_descending,
                             test_kvpartial_sort_ascending,
-                            test_kvpartial_sort_descending,
-                            test_validator);
+                            test_kvpartial_sort_descending);
 
 #define CREATE_TUPLES(type) \
     std::tuple<double, type>, std::tuple<uint64_t, type>, \

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -29,6 +29,57 @@ public:
 
 TYPED_TEST_SUITE_P(simdkvsort);
 
+template <typename T>
+bool same_values(T* v1, T* v2, size_t size){
+    // Checks that the values are the same except (maybe) their ordering
+    auto cmp_eq = compare<T, std::equal_to<T>>();
+    
+    // TODO hardcoding hasnan to true doesn't break anything right?
+    x86simdsort::qsort(v1, size, true);
+    x86simdsort::qsort(v2, size, true);
+    
+    for (size_t i = 0; i < size; i++){
+        if (!cmp_eq(v1[i], v2[i])){
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+template <typename T1, typename T2>
+bool kv_equivalent(T1* keys_comp, T2* vals_comp, T1* keys_ref, T2* vals_ref, size_t size){
+    auto cmp_eq = compare<T1, std::equal_to<T1>>();
+    
+    // First check keys are exactly identical
+    for (size_t i = 0; i < size; i++){
+        if (!cmp_eq(keys_comp[i], keys_ref[i])){
+            return false;
+        }
+    }
+    
+    size_t i_start = 0;
+    T1 key_start = keys_comp[0];
+    // Loop through all identical keys in a block, then compare the sets of values to make sure they are identical
+    // We need the index after the loop
+    size_t i = 0;
+    for (; i < size; i++){
+        if (!cmp_eq(keys_comp[i], key_start)){
+            // Check that every value in 
+
+            if (!same_values(vals_ref + i_start, vals_comp + i_start, i - i_start)){
+                return false;
+            }
+            
+            // Now setup the start variables to begin gathering keys for the next group
+            i_start = i;
+            key_start = keys_comp[i];
+        }
+    }
+    
+    return true;
+}
+
 TYPED_TEST_P(simdkvsort, test_kvsort)
 {
     using T1 = typename std::tuple_element<0, decltype(TypeParam())>::type;
@@ -43,10 +94,10 @@ TYPED_TEST_P(simdkvsort, test_kvsort)
             x86simdsort::keyvalue_qsort(key.data(), val.data(), size, hasnan);
             xss::scalar::keyvalue_qsort(
                     key_bckp.data(), val_bckp.data(), size, hasnan);
-            ASSERT_EQ(key, key_bckp);
-            const bool hasDuplicates
-                    = std::adjacent_find(key.begin(), key.end()) != key.end();
-            if (!hasDuplicates) { ASSERT_EQ(val, val_bckp); }
+            
+            bool is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), size);
+            ASSERT_EQ(is_kv_equivalent, true);
+            
             key.clear();
             val.clear();
             key_bckp.clear();
@@ -55,7 +106,53 @@ TYPED_TEST_P(simdkvsort, test_kvsort)
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(simdkvsort, test_kvsort);
+TYPED_TEST_P(simdkvsort, test_validator)
+{
+    // Tests a few edge cases to verify the tests are working correctly and identifying it as functional
+    using T1 = typename std::tuple_element<0, decltype(TypeParam())>::type;
+    using T2 = typename std::tuple_element<1, decltype(TypeParam())>::type;
+    
+    bool is_kv_equivalent;
+    
+    std::vector<T1> key = {0, 0, 1, 1};
+    std::vector<T2> val = {1, 2, 3, 4};
+    std::vector<T1> key_bckp = key;
+    std::vector<T2> val_bckp = val;
+    
+    // Duplicate keys, but otherwise exactly identical
+    is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), key.size());
+    ASSERT_EQ(is_kv_equivalent, true);
+    
+    val = {2,1,4,3};
+    
+    // Now values are backwards, but this is still fine
+    is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), key.size());
+    ASSERT_EQ(is_kv_equivalent, true);
+    
+    val = {1,3,2,4};
+    
+    // Now values are mixed up, should fail
+    is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), key.size());
+    ASSERT_EQ(is_kv_equivalent, false);
+    
+    val = {1,2,3,4};
+    key = {0,0,0,0};
+    
+    // Now keys are messed up, should fail
+    is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), key.size());
+    ASSERT_EQ(is_kv_equivalent, false);
+    
+    key = {0,0,0,0,0,0};
+    key_bckp = key;
+    val_bckp = {1,2,3,4,5,6};
+    val = {4,3,1,6,5,2};
+    
+    // All keys identical, simply reordered values
+    is_kv_equivalent = kv_equivalent<T1, T2>(key.data(), val.data(), key_bckp.data(), val_bckp.data(), key.size());
+    ASSERT_EQ(is_kv_equivalent, true);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(simdkvsort, test_kvsort, test_validator);
 
 #define CREATE_TUPLES(type) \
     std::tuple<double, type>, std::tuple<uint64_t, type>, \

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -181,8 +181,7 @@ TYPED_TEST_P(simdsort, test_partial_qsort_ascending)
     for (auto type : this->arrtype) {
         bool hasnan = (type == "rand_with_nan") ? true : false;
         for (auto size : this->arrsize) {
-            // k should be at least 1
-            size_t k = std::max((size_t)1, rand() % size);
+            size_t k = rand() % size;
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
 
             // Ascending order

--- a/utils/custom-compare.h
+++ b/utils/custom-compare.h
@@ -1,3 +1,6 @@
+#ifndef UTILS_CUSTOM_COMPARE
+#define UTILS_CUSTOM_COMPARE
+
 #include <limits>
 #include <cmath>
 #include "xss-custom-float.h"
@@ -42,3 +45,5 @@ struct compare_arg {
     }
     const T *arr;
 };
+
+#endif // UTILS_CUSTOM_COMPARE


### PR DESCRIPTION
This patch adds support for descending kv-sort and ascending/descending kv-select and kv-partial_sort
For reference, some benchmarks comparing to Pytorch's scalar implementation are provided:

With normally distributed float32:
```                                                                          
Partial Sort (sorted topk):                                                                           
size           default        avx2           avx512         AVX2 speedup % AVX512 speedup %
16             4.180374384    4.0826931      4.202754736    -2.336663537   0.53536717     
128            5.362578869    6.11398387     5.229052782    14.01200838    -2.489960336   
1024           14.10357333    14.0685565     9.240571122    -0.248283326   -34.48063899   
10000          322.740033     89.83533496    48.29404964    -72.1647996    -85.03623824   
100000         3757.874566    1168.889193    721.571655     -68.89493856   -80.79841032   
1000000        45415.52301    11909.35397    8130.106271    -73.77690891   -82.09839779   
10000000       539107.6565    217536.211     171638.298     -59.64883667   -68.16251894   
100000000      6410786.629    2307972.193    1874841.69     -63.99861161   -70.75488862   
                                                                                          
Select (unsorted topk):                                                                           
size           default        avx2           avx512         AVX2 speedup % AVX512 speedup %                                      
16             4.046328783    4.075162649    4.120069742    0.712593258    1.822416396    
128            4.912573099    5.651566267    4.852572441    15.04289408    -1.221369267   
1024           9.33410556     7.444588822    6.450861102    -20.24314731   -30.88934917   
10000          131.0603339    30.31828351    21.59984892    -76.8669264    -83.5191562    
100000         1273.479035    461.2905271    368.7236242    -63.77714006   -71.04596038   
1000000        12720.43527    4615.330229    6321.014143    -63.71719891   -50.30819302   
10000000       253137.2547    130307.7698    125634.7179    -48.52287945   -50.36893401   
100000000      2394076.347    1226446.152    1257464.17     -48.77163575   -47.47602048   
```      
                                                                          
With uniformly distributed (from 0 to 10e9) int32: 
```                                                                          
Partial Sort (sorted topk):                                                                           
size           default        avx2           avx512         AVX2 speedup % AVX512 speedup %
16             4.159518957    4.193886042    4.062754393    0.82622738     -2.326340269   
128            4.946233034    6.055155277    5.076540947    22.41953089    2.634487941    
1024           10.11158738    12.40083982    8.094132173    22.63989176    -19.95191391   
10000          235.6421399    81.19698569    47.26006824    -65.54224736   -79.94413552   
100000         2726.637111    1325.142324    692.2358897    -51.40012146   -74.61210049   
1000000        32515.39025    13960.33343    7689.116048    -57.06545939   -76.35237963   
10000000       461327.1713    221366.8823    176379.2038    -52.01520828   -61.76700295   
100000000      5129393.339    2428071.022    1890691.996    -52.66358297   -63.14004658   
                                                                                          
Select (unsorted topk):                                                                           
size           default        avx2           avx512         AVX2 speedup % AVX512 speedup %                             
16             7.28207159     7.344153643    7.334493876    0.852532847    0.719881485    
128            7.539570808    9.854883432    8.218926668    30.70881198    9.010537563    
1024           14.03857871    19.15253601    10.045604      36.427885      -28.4428701    
10000          146.630404     48.96809058    29.91605115    -66.60440861   -79.59764801   
100000         1304.309364    585.7699348    807.1453417    -55.08964737   -38.11703236   
1000000        16298.37354    7968.290179    8426.867279    -51.10990578   -48.29626859   
10000000       276746.4638    175631.3324    161258.0299    -36.5370997    -41.73077129   
100000000      3139316.559    1701539.516    1615918.875    -45.79904624   -48.5264119  
```