### PR TITLE
Add flags to support OpenBSD

### DIFF
--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -10,7 +10,8 @@ static int check_cpu_feature_support(std::string_view cpufeature)
     const char *disable_avx512 = std::getenv("XSS_DISABLE_AVX512");
 
     if ((cpufeature == "avx512_spr") && (!disable_avx512))
-#if defined(__FLT16_MAX__) && !defined(__INTEL_LLVM_COMPILER)
+#if defined(__FLT16_MAX__) && !defined(__INTEL_LLVM_COMPILER) \
+        && __clang_major__ >= 18
         return __builtin_cpu_supports("avx512f")
                 && __builtin_cpu_supports("avx512fp16")
                 && __builtin_cpu_supports("avx512vbmi2");

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -406,10 +406,10 @@ struct avx2_vector<uint64_t> {
 };
 
 /*
- * workaround on 64-bit macOS which defines size_t as unsigned long and defines
- * uint64_t as unsigned long long, both of which are 8 bytes
+ * workaround on 64-bit macOS and OpenBSD which both define size_t as unsigned
+ * long and define uint64_t as unsigned long long, both of which are 8 bytes
  */
-#if defined(__APPLE__) && defined(__x86_64__)
+#if (defined(__APPLE__) || defined(__OpenBSD__)) && defined(__x86_64__)
 static_assert(sizeof(size_t) == sizeof(uint64_t),
               "Size of size_t and uint64_t are not the same");
 template <>

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -960,10 +960,10 @@ struct zmm_vector<uint64_t> {
 };
 
 /*
- * workaround on 64-bit macOS which defines size_t as unsigned long and defines
- * uint64_t as unsigned long long, both of which are 8 bytes
+ * workaround on 64-bit macOS and OpenBSD which both define size_t as unsigned
+ * long and define uint64_t as unsigned long long, both of which are 8 bytes
  */
-#if defined(__APPLE__) && defined(__x86_64__)
+#if (defined(__APPLE__) || defined(__OpenBSD__)) && defined(__x86_64__)
 static_assert(sizeof(size_t) == sizeof(uint64_t),
               "Size of size_t and uint64_t are not the same");
 template <>


### PR DESCRIPTION
# Summary

There are two primary changes included here. This commit aims to address #156 

# Type length

This commit includes OpenBSD in the platform checks used to check for size_t, uint64_t, unsigned long and unsigned long long all being 64 bits in length.

Consider the following C code compiled and run on the target platform

```c
#include <unistd.h>
#include <stdio.h>

int
main(int argc, char **argv)
{
        printf("sizeof(unsigned long) = %d\n", sizeof(unsigned long));
        printf("sizeof(long) = %d\n", sizeof(long));
        printf("sizeof(int64_t = %d\n", sizeof(int64_t));
        printf("sizeof(unsigned long long) = %d\n", sizeof(unsigned long long));
        printf("sizeof(uint64_t) = %d\n", sizeof(uint64_t));
        printf("sizeof(long *) = %d\n", sizeof(long *));
        printf("sizeof(uint64_t *) = %d\n", sizeof(uint64_t *));
        return 0;
}
```
When compiled and run:
```sh
 $ ./sizes 
sizeof(unsigned long) = 8
sizeof(long) = 8
sizeof(int64_t = 8
sizeof(unsigned long long) = 8
sizeof(uint64_t) = 8
sizeof(long *) = 8
sizeof(uint64_t *) = 8
```

# Invalid CPU Feature String

Addtionally, the checks for some `avx513*` flags are removed, as `avx512fp16` yield an error: "invalid cpu feature string for builtin" when compiling with clang.

Possibly related to https://github.com/llvm/llvm-project/issues/65320

# Testing

The compilation step succeeds and results in the following:
```sh
host$ pwd
/home/user/x86-simd-sort/builddir
host$ ls -l lib/
total 144
-rw-r--r--  1 user  user  21368 Jun 20 13:43 liblibavx.a
drwxr-xr-x  2 user  user    512 Jun 20 13:43 liblibavx.a.p
-rw-r--r--  1 user  user   2506 Jun 20 13:43 liblibicl.a
drwxr-xr-x  2 user  user    512 Jun 20 13:42 liblibicl.a.p
-rw-r--r--  1 user  user  20704 Jun 20 13:43 liblibskx.a
drwxr-xr-x  2 user  user    512 Jun 20 13:43 liblibskx.a.p
-rw-r--r--  1 user  user   1378 Jun 20 13:43 liblibspr.a
drwxr-xr-x  2 user  user    512 Jun 20 13:42 liblibspr.a.p

```

I attempted to build `numpy` updating the submodule for this project to use my fork. It passes the original failure I encountered but still fails. This indicates I have other dependencies to validate. I can conclusively say the changes here do not make the situation worse!