### PR TITLE
Documentation fixes

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,8 +2,8 @@
 
 C++ header file library for SIMD based 16-bit, 32-bit and 64-bit data type
 sorting algorithms on x86 processors. We currently have AVX-512 and AVX2
-(32-bit and 64-bit only) based implementation of quicksort, quickselect &
-partialsort and AVX-512 implementations of argsort, argselect and key-value
+(32-bit and 64-bit only) based implementation of quicksort, quickselect,
+partialsort, argsort, argselect & key-value
 sort. The following API's are currently supported:
 
 #### Quicksort
@@ -30,8 +30,8 @@ Equivalent to `std::nth_element` in
 
 
 ```cpp
-void avx512_qselect<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
-void avx2_qselect<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx512_qselect<T>(T* arr, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx2_qselect<T>(T* arr, size_t k, size_t arrsize, bool hasnan = false, bool descending = false);
 ```
 Supported datatypes: `uint16_t`, `int16_t`, `_Float16`, `uint32_t`, `int32_t`,
 `float`, `uint64_t`, `int64_t` and `double`. AVX2 versions currently support
@@ -46,8 +46,8 @@ Equivalent to `std::partial_sort` in
 
 
 ```cpp
-void avx512_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false)
-void avx2_partial_qsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false)
+void avx512_partial_qsort<T>(T* arr, size_t k, size_t arrsize, bool hasnan = false, bool descending = false)
+void avx2_partial_qsort<T>(T* arr, size_t k, size_t arrsize, bool hasnan = false, bool descending = false)
 ```
 Supported datatypes: `uint16_t`, `int16_t`, `_Float16`, `uint32_t`, `int32_t`,
 `float`, `uint64_t`, `int64_t` and `double`. AVX2 versions currently support
@@ -61,8 +61,8 @@ Equivalent to `np.argsort` in
 [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.argsort.html).
 
 ```cpp
-std::vector<size_t> arg = avx512_argsort<T>(T* arr, size_t arrsize, bool hasnan = false, bool descending = false);
 void avx512_argsort<T>(T* arr, size_t *arg, size_t arrsize, bool hasnan = false, bool descending = false);
+void avx2_argsort<T>(T* arr, size_t *arg, size_t arrsize, bool hasnan = false, bool descending = false);
 ```
 Supported datatypes: `uint32_t`, `int32_t`, `float`, `uint64_t`, `int64_t` and
 `double`.
@@ -74,8 +74,8 @@ Equivalent to `np.argselect` in
 [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.argpartition.html).
 
 ```cpp
-std::vector<size_t> arg = avx512_argselect<T>(T* arr, size_t k, size_t arrsize);
 void avx512_argselect<T>(T* arr, size_t *arg, size_t k, size_t arrsize);
+void avx2_argselect<T>(T* arr, size_t *arg, size_t k, size_t arrsize);
 ```
 Supported datatypes: `uint32_t`, `int32_t`, `float`, `uint64_t`, `int64_t` and
 `double`.
@@ -84,9 +84,10 @@ The algorithm resorts to scalar `std::sort` if the array contains NaNs.
 
 #### Key-value sort
 ```cpp
-void avx512_qsort_kv<T>(T1* key, T2* value , size_t arrsize)
+void avx512_qsort_kv<T1, T2>(T1* key, T2* value, size_t arrsize);
+void avx2_qsort_kv<T1, T2>(T1* key, T2* value, size_t arrsize);
 ```
-Supported datatypes: `uint64_t, int64_t and double`
+Supported datatypes: `uint64_t`, `int64_t` and `double`.
 
 ## Algorithm details
 
@@ -105,6 +106,8 @@ source code associated with that paper [3].
 ### Sample code `main.cpp`
 
 ```cpp
+#include "src/xss-common-includes.h"
+#include "src/xss-common-qsort.h"
 #include "src/avx512-32bit-qsort.hpp"
 
 int main() {


### PR DESCRIPTION
This pull request fixes some mistakes in the previous documentation, and reflects recent API changes.

1. AVX2 now also has `argsort`, `argselect`, and key-value sort.
2. Adds the missing argument `k` in `qselect` and `partial_qsort`.
3. The version of `argsort` that returns a `std::vector` has been removed. Similar for `argselect`.
4. Fixes the template parameters in `avx512_qsort_kv`.
5. The sample code needs to include some `xss-common-*` headers to compile.