### PR TITLE
CI: use intel-ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/build-numpy.yml
+++ b/.github/workflows/build-numpy.yml
@@ -14,7 +14,7 @@ jobs:
   np-multiarray-tgl:
 
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - name: Checkout x86-simd-sort
@@ -80,7 +80,7 @@ jobs:
   np-multiarray-spr:
 
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - name: Checkout x86-simd-sort

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   SKL-gcc9:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -41,7 +41,7 @@ jobs:
 
   SKX-gcc10:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -71,7 +71,7 @@ jobs:
 
   TGL-gcc11:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -100,7 +100,7 @@ jobs:
 
   SPR-gcc13:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -137,7 +137,7 @@ jobs:
 
   SKX-SKL-openmp:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -169,7 +169,7 @@ jobs:
 
   SPR-gcc13-special-cases:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -204,7 +204,7 @@ jobs:
 
   manylinux-32bit:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -216,7 +216,7 @@ jobs:
 
   SPR-icpx:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   clang-format:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
   
     name: Scorecard analysis
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: ubuntu-latest
+    runs-on: intel-ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Fixes some of the CI failures we are seeing with missing g++-13