### PR TITLE
Fixes bug with nested OpenMP, fixed task threshold, extended tests range

### DIFF
--- a/.github/workflows/build-numpy.yml
+++ b/.github/workflows/build-numpy.yml
@@ -14,7 +14,7 @@ jobs:
   np-multiarray-tgl:
 
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - name: Checkout x86-simd-sort
@@ -80,7 +80,7 @@ jobs:
   np-multiarray-spr:
 
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - name: Checkout x86-simd-sort

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   SKL-gcc9:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -41,7 +41,7 @@ jobs:
 
   SKX-gcc10:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -71,7 +71,7 @@ jobs:
 
   TGL-gcc11:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -100,7 +100,7 @@ jobs:
 
   SPR-gcc13:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -137,7 +137,7 @@ jobs:
 
   SKX-SKL-openmp:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -169,7 +169,7 @@ jobs:
 
   SPR-gcc13-special-cases:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -204,7 +204,7 @@ jobs:
 
   manylinux-32bit:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -216,7 +216,7 @@ jobs:
 
   SPR-icpx:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -226,8 +226,7 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt update --allow-insecure-repositories
-        sudo apt --allow-unauthenticated -y install intel-oneapi-compiler-dpcpp-cpp libgtest-dev curl git python3-pip
-        sudo pip3 install meson ninja
+        sudo apt --allow-unauthenticated -y install intel-oneapi-compiler-dpcpp-cpp libgtest-dev curl git python3-pip meson
 
     - name: Install Intel SDE
       run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   clang-format:
 
-    runs-on: intel-ubuntu-latest
+    runs-on: intel-ubuntu-24.04
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
   
     name: Scorecard analysis
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: ubuntu-latest
+    runs-on: intel-ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -559,9 +559,14 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
                     keys, indexes, 0, arrsize - 1, maxiters, task_threshold);
         }
         else {
-            kvsort_<keytype, valtype>(
-                    keys, indexes, 0, arrsize - 1, maxiters, 0);
+            kvsort_<keytype, valtype>(keys,
+                                      indexes,
+                                      0,
+                                      arrsize - 1,
+                                      maxiters,
+                                      std::numeric_limits<arrsize_t>::max());
         }
+#pragma omp taskwait
 #else
         kvsort_<keytype, valtype>(keys, indexes, 0, arrsize - 1, maxiters, 0);
 #endif

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -15,6 +15,10 @@ public:
     simdkvsort()
     {
         std::iota(arrsize.begin(), arrsize.end(), 1);
+        arrsize.push_back(10'000);
+        arrsize.push_back(100'000);
+        arrsize.push_back(1'000'000);
+
         arrtype = {"random",
                    "constant",
                    "sorted",


### PR DESCRIPTION
Fixes the bug with nested OpenMP by adding #pragma omp taskwait
Changes the task_threshold when OpenMP is enabled but parallelization isn't chosen from 0 to the max value for arrsize_t; I don't think this was causing any problems, but it was definitely a mistake
Additionally, extended the kvsort tests to also run for sizes of 10^4, 10^5, 10^6 for testing the OpenMP logic
