### PR TITLE
Update reference link to use https with default port

### DIFF
--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -31,7 +31,7 @@
  *
  * [3] https://github.com/simd-sorting/fast-and-robust: SPDX-License-Identifier: MIT
  *
- * [4] http://mitp-content-server.mit.edu:18180/books/content/sectbyfn?collid=books_pres_0&fn=Chapter%2027.pdf&id=8030
+ * [4] https://mitp-content-server.mit.edu/books/content/sectbyfn?collid=books_pres_0&fn=Chapter%2027.pdf&id=8030
  *
  */
 #include "xss-pivot-selection.hpp"


### PR DESCRIPTION
Please review this trivbial PR which proposes that a documentation link in `xss-common-qsort.h` be updated from using http:// with a non-default port to using https:// with the default port.