### PR TITLE
Fix kvsort/kvselect nan behavior and added tests for mixed nan/inf arrays

### DIFF
--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -586,6 +586,9 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
                                       half_vector<T2>,
                                       full_vector<T2>>::type;
 
+    // Exit early if no work would be done
+    if (arrsize <= 1) return;
+
 #ifdef XSS_TEST_KEYVALUE_BASE_CASE
     int maxiters = -1;
     bool minarrsize = true;
@@ -674,6 +677,9 @@ X86_SIMD_SORT_INLINE void xss_select_kv(T1 *keys,
                                               && sizeof(T2) == sizeof(int32_t),
                                       half_vector<T2>,
                                       full_vector<T2>>::type;
+
+    // Exit early if no work would be done
+    if (arrsize <= 1) return;
 
 #ifdef XSS_TEST_KEYVALUE_BASE_CASE
     int maxiters = -1;

--- a/tests/test-qsort-common.h
+++ b/tests/test-qsort-common.h
@@ -20,6 +20,12 @@
     ASSERT_TRUE(false) << msg << ". arr size = " << size \
                        << ", type = " << type << ", k = " << k;
 
+inline bool is_nan_test(std::string type)
+{
+    // Currently, determine whether the test uses nan just be checking if nan is in its name
+    return type.find("nan") != std::string::npos;
+}
+
 template <typename T>
 void IS_SORTED(std::vector<T> sorted, std::vector<T> arr, std::string type)
 {

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -19,7 +19,8 @@ public:
                    "max_at_the_end",
                    "random_5d",
                    "rand_max",
-                   "rand_with_nan"};
+                   "rand_with_nan",
+                   "rand_with_max_and_nan"};
     }
     std::vector<std::string> arrtype;
     std::vector<size_t> arrsize = std::vector<size_t>(1024);
@@ -30,7 +31,7 @@ TYPED_TEST_SUITE_P(simdsort);
 TYPED_TEST_P(simdsort, test_qsort_ascending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
 
@@ -52,7 +53,7 @@ TYPED_TEST_P(simdsort, test_qsort_ascending)
 TYPED_TEST_P(simdsort, test_qsort_descending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
 
@@ -74,7 +75,7 @@ TYPED_TEST_P(simdsort, test_qsort_descending)
 TYPED_TEST_P(simdsort, test_argsort_ascending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
             std::vector<TypeParam> sortedarr = arr;
@@ -92,7 +93,7 @@ TYPED_TEST_P(simdsort, test_argsort_ascending)
 TYPED_TEST_P(simdsort, test_argsort_descending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
             std::vector<TypeParam> sortedarr = arr;
@@ -111,7 +112,7 @@ TYPED_TEST_P(simdsort, test_argsort_descending)
 TYPED_TEST_P(simdsort, test_qselect_ascending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             size_t k = rand() % size;
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
@@ -135,7 +136,7 @@ TYPED_TEST_P(simdsort, test_qselect_ascending)
 TYPED_TEST_P(simdsort, test_qselect_descending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             size_t k = rand() % size;
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
@@ -159,7 +160,7 @@ TYPED_TEST_P(simdsort, test_qselect_descending)
 TYPED_TEST_P(simdsort, test_argselect)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             size_t k = rand() % size;
             std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
@@ -179,7 +180,7 @@ TYPED_TEST_P(simdsort, test_argselect)
 TYPED_TEST_P(simdsort, test_partial_qsort_ascending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             size_t k = rand() % size;
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
@@ -202,7 +203,7 @@ TYPED_TEST_P(simdsort, test_partial_qsort_ascending)
 TYPED_TEST_P(simdsort, test_partial_qsort_descending)
 {
     for (auto type : this->arrtype) {
-        bool hasnan = (type == "rand_with_nan") ? true : false;
+        bool hasnan = is_nan_test(type);
         for (auto size : this->arrsize) {
             // k should be at least 1
             size_t k = std::max((size_t)1, rand() % size);

--- a/utils/rand_array.h
+++ b/utils/rand_array.h
@@ -140,6 +140,26 @@ static std::vector<T> get_array(std::string arrtype,
             if (rand() & 0x1) { arr[ii] = val; }
         }
     }
+    else if (arrtype == "rand_with_max_and_nan") {
+        arr = get_uniform_rand_array<T>(arrsize, max, min);
+        T max_val;
+        T nan_val;
+        if constexpr (xss::fp::is_floating_point_v<T>) {
+            max_val = xss::fp::infinity<T>();
+            nan_val = xss::fp::quiet_NaN<T>();
+        }
+        else {
+            max_val = std::numeric_limits<T>::max();
+            nan_val = std::numeric_limits<T>::max();
+        }
+        for (size_t ii = 0; ii < arrsize; ++ii) {
+            int res = rand() % 4;
+            if (res == 2) { arr[ii] = max_val; }
+            else if (res == 3) {
+                arr[ii] = nan_val;
+            }
+        }
+    }
     else {
         std::cout << "Warning: unrecognized array type " << arrtype
                   << std::endl;


### PR DESCRIPTION
I identified two bugs related to the handling of nans in the kvsort/kvselect logic.
1) kvselect (and thus kvpartialsort) would produce incorrect results when using descending order on arrays with nans
2) kvsort would produce invalid results when given arrays containing both infinity and nan

This patch should fix both of these issues, and it adds a test with mixed inf/nan arrays for all of the qsort/kvsort tests. From my testing, it seems to have a negligible performance impact.