### PR TITLE
Adds OpenMP to qsort, should also improve test speed a bit

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -34,7 +34,7 @@ if cpp.has_argument('-march=icelake-client')
       'x86simdsort-icl.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=icelake-client'],
+    cpp_args : ['-march=icelake-client', openmpflags],
     gnu_symbol_visibility : 'inlineshidden',
     )
 endif
@@ -45,7 +45,7 @@ if cancompilefp16
       'x86simdsort-spr.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=sapphirerapids'],
+    cpp_args : ['-march=sapphirerapids', openmpflags],
     gnu_symbol_visibility : 'inlineshidden',
     )
 endif

--- a/src/avx512-16bit-common.h
+++ b/src/avx512-16bit-common.h
@@ -14,11 +14,11 @@ struct avx512_16bit_swizzle_ops {
         __m512i v = vtype::cast_to(reg);
 
         if constexpr (scale == 2) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {1,  0,  3,  2,  5,  4,  7,  6,  9,  8,  11,
                        10, 13, 12, 15, 14, 17, 16, 19, 18, 21, 20,
                        23, 22, 25, 24, 27, 26, 29, 28, 31, 30};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 4) {
@@ -48,27 +48,27 @@ struct avx512_16bit_swizzle_ops {
 
         if constexpr (scale == 2) { return swap_n<vtype, 2>(reg); }
         else if constexpr (scale == 4) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {3,  2,  1,  0,  7,  6,  5,  4,  11, 10, 9,
                        8,  15, 14, 13, 12, 19, 18, 17, 16, 23, 22,
                        21, 20, 27, 26, 25, 24, 31, 30, 29, 28};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 8) {
-            std::vector<uint16_t> arr
+            constexpr static int16_t arr[]
                     = {7,  6,  5,  4,  3,  2,  1,  0,  15, 14, 13,
                        12, 11, 10, 9,  8,  23, 22, 21, 20, 19, 18,
                        17, 16, 31, 30, 29, 28, 27, 26, 25, 24};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 16) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {15, 14, 13, 12, 11, 10, 9,  8,  7,  6,  5,
                        4,  3,  2,  1,  0,  31, 30, 29, 28, 27, 26,
                        25, 24, 23, 22, 21, 20, 19, 18, 17, 16};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 32) {

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -556,6 +556,7 @@ avx512_qsort_fp16(uint16_t *arr,
 {
     using vtype = zmm_vector<float16>;
 
+    // TODO multithreading support here
     if (arrsize > 1) {
         arrsize_t nan_count = 0;
         if (UNLIKELY(hasnan)) {
@@ -564,11 +565,11 @@ avx512_qsort_fp16(uint16_t *arr,
         }
         if (descending) {
             qsort_<vtype, Comparator<vtype, true>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
+                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
         }
         else {
             qsort_<vtype, Comparator<vtype, false>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
+                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
         }
         replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -968,8 +968,7 @@ struct zmm_vector<uint64_t> {
 static_assert(sizeof(size_t) == sizeof(uint64_t),
               "Size of size_t and uint64_t are not the same");
 template <>
-struct zmm_vector<size_t> : public zmm_vector<uint64_t> {
-};
+struct zmm_vector<size_t> : public zmm_vector<uint64_t> {};
 #endif
 
 template <>

--- a/src/avx512-64bit-common.h
+++ b/src/avx512-64bit-common.h
@@ -968,7 +968,8 @@ struct zmm_vector<uint64_t> {
 static_assert(sizeof(size_t) == sizeof(uint64_t),
               "Size of size_t and uint64_t are not the same");
 template <>
-struct zmm_vector<size_t> : public zmm_vector<uint64_t> {};
+struct zmm_vector<size_t> : public zmm_vector<uint64_t> {
+};
 #endif
 
 template <>

--- a/src/avx512fp16-16bit-qsort.hpp
+++ b/src/avx512fp16-16bit-qsort.hpp
@@ -22,7 +22,7 @@ struct zmm_vector<_Float16> {
     using opmask_t = __mmask32;
     static const uint8_t numlanes = 32;
     static constexpr int network_sort_threshold = 128;
-    static constexpr int partition_unroll_factor = 0;
+    static constexpr int partition_unroll_factor = 8;
     static constexpr simd_type vec_type = simd_type::AVX512;
 
     using swizzle_ops = avx512_16bit_swizzle_ops;

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -82,6 +82,11 @@
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, \
             21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 
+#if defined(XSS_USE_OPENMP) && defined(_OPENMP)
+#define XSS_COMPILE_OPENMP
+#include <omp.h>
+#endif
+
 template <class... T>
 constexpr bool always_false = false;
 

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -11,11 +11,6 @@
 #include "xss-common-qsort.h"
 #include "xss-network-keyvaluesort.hpp"
 
-#if defined(XSS_USE_OPENMP) && defined(_OPENMP)
-#define XSS_COMPILE_OPENMP
-#include <omp.h>
-#endif
-
 /*
  * Sort all the NAN's to end of the array and return the index of the last elem
  * in the array which is not a nan

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -663,14 +663,14 @@ X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
 
 #ifdef XSS_COMPILE_OPENMP
 
-        bool use_parallel = arrsize > 10000;
+        bool use_parallel = arrsize > 100000;
 
         if (use_parallel) {
             // This thread limit was determined experimentally; it may be better for it to be the number of physical cores on the system
             constexpr int thread_limit = 8;
             int thread_count = std::min(thread_limit, omp_get_max_threads());
             arrsize_t task_threshold
-                    = std::max((arrsize_t)10000, arrsize / 100);
+                    = std::max((arrsize_t)100000, arrsize / 100);
 
             // We use omp parallel and then omp single to setup the threads that will run the omp task calls in qsort_
             // The omp single prevents multiple threads from running the initial qsort_ simultaneously and causing problems

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -521,8 +521,11 @@ template <typename vtype, int maxN>
 void sort_n(typename vtype::type_t *arr, int N);
 
 template <typename vtype, typename comparator, typename type_t>
-static void
-qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
+static void qsort_(type_t *arr,
+                   arrsize_t left,
+                   arrsize_t right,
+                   arrsize_t max_iters,
+                   arrsize_t task_threshold)
 {
     /*
      * Resort to std::sort if quicksort isnt making any progress
@@ -559,10 +562,40 @@ qsort_(type_t *arr, arrsize_t left, arrsize_t right, arrsize_t max_iters)
     type_t leftmostValue = comparator::leftmost(smallest, biggest);
     type_t rightmostValue = comparator::rightmost(smallest, biggest);
 
+#ifdef XSS_COMPILE_OPENMP
+    if (pivot != leftmostValue) {
+        bool parallel_left = (pivot_index - left) > task_threshold;
+        if (parallel_left) {
+#pragma omp task
+            qsort_<vtype, comparator>(
+                    arr, left, pivot_index - 1, max_iters - 1, task_threshold);
+        }
+        else {
+            qsort_<vtype, comparator>(
+                    arr, left, pivot_index - 1, max_iters - 1, task_threshold);
+        }
+    }
+    if (pivot != rightmostValue) {
+        bool parallel_right = (right - pivot_index) > task_threshold;
+
+        if (parallel_right) {
+#pragma omp task
+            qsort_<vtype, comparator>(
+                    arr, pivot_index, right, max_iters - 1, task_threshold);
+        }
+        else {
+            qsort_<vtype, comparator>(
+                    arr, pivot_index, right, max_iters - 1, task_threshold);
+        }
+    }
+#else
+    UNUSED(task_threshold);
+
     if (pivot != leftmostValue)
-        qsort_<vtype, comparator>(arr, left, pivot_index - 1, max_iters - 1);
+        qsort_<vtype, comparator>(arr, left, pivot_index - 1, max_iters - 1, 0);
     if (pivot != rightmostValue)
-        qsort_<vtype, comparator>(arr, pivot_index, right, max_iters - 1);
+        qsort_<vtype, comparator>(arr, pivot_index, right, max_iters - 1, 0);
+#endif
 }
 
 template <typename vtype, typename comparator, typename type_t>
@@ -627,8 +660,41 @@ X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
         }
 
         UNUSED(hasnan);
+
+#ifdef XSS_COMPILE_OPENMP
+
+        bool use_parallel = arrsize > 10000;
+
+        if (use_parallel) {
+            // This thread limit was determined experimentally; it may be better for it to be the number of physical cores on the system
+            constexpr int thread_limit = 8;
+            int thread_count = std::min(thread_limit, omp_get_max_threads());
+            arrsize_t task_threshold
+                    = std::max((arrsize_t)10000, arrsize / 100);
+
+            // We use omp parallel and then omp single to setup the threads that will run the omp task calls in qsort_
+            // The omp single prevents multiple threads from running the initial qsort_ simultaneously and causing problems
+            // Note that we do not use the if(...) clause built into OpenMP, because it causes a performance regression for small arrays
+#pragma omp parallel num_threads(thread_count)
+#pragma omp single
+            qsort_<vtype, comparator, T>(arr,
+                                         0,
+                                         arrsize - 1,
+                                         2 * (arrsize_t)log2(arrsize),
+                                         task_threshold);
+        }
+        else {
+            qsort_<vtype, comparator, T>(arr,
+                                         0,
+                                         arrsize - 1,
+                                         2 * (arrsize_t)log2(arrsize),
+                                         std::numeric_limits<arrsize_t>::max());
+        }
+#pragma omp taskwait
+#else
         qsort_<vtype, comparator, T>(
-                arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
+                arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+#endif
 
         replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,19 +1,26 @@
 libtests = []
 
+if get_option('use_openmp')
+  openmpflags = ['-DXSS_USE_OPENMP=true']
+endif
+
 libtests += static_library('tests_qsort',
   files('test-qsort.cpp', ),
   dependencies: gtest_dep,
   include_directories : [src, lib, utils],
+  cpp_args : [openmpflags],
   )
 
 libtests += static_library('tests_kvsort',
   files('test-keyvalue.cpp', ),
   dependencies: gtest_dep,
   include_directories : [src, lib, utils],
+  cpp_args : [openmpflags],
   )
 
 libtests += static_library('tests_objsort',
   files('test-objqsort.cpp', ),
   dependencies: gtest_dep,
   include_directories : [src, lib, utils],
+  cpp_args : [openmpflags],
   )

--- a/tests/test-keyvalue.cpp
+++ b/tests/test-keyvalue.cpp
@@ -15,9 +15,13 @@ public:
     simdkvsort()
     {
         std::iota(arrsize.begin(), arrsize.end(), 1);
-        arrsize.push_back(10'000);
-        arrsize.push_back(100'000);
-        arrsize.push_back(1'000'000);
+        std::iota(arrsize_long.begin(), arrsize_long.end(), 1);
+#ifdef XSS_USE_OPENMP
+        // These extended tests are only needed for the OpenMP logic
+        arrsize_long.push_back(10'000);
+        arrsize_long.push_back(100'000);
+        arrsize_long.push_back(1'000'000);
+#endif
 
         arrtype = {"random",
                    "constant",
@@ -32,6 +36,7 @@ public:
     }
     std::vector<std::string> arrtype;
     std::vector<size_t> arrsize = std::vector<size_t>(1024);
+    std::vector<size_t> arrsize_long = std::vector<size_t>(1024);
 };
 
 TYPED_TEST_SUITE_P(simdkvsort);
@@ -168,7 +173,7 @@ TYPED_TEST_P(simdkvsort, test_kvsort_ascending)
     using T2 = typename std::tuple_element<1, decltype(TypeParam())>::type;
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<T1> key = get_array<T1>(type, size);
             std::vector<T2> val = get_array<T2>(type, size);
             std::vector<T1> key_bckp = key;
@@ -199,7 +204,7 @@ TYPED_TEST_P(simdkvsort, test_kvsort_descending)
     using T2 = typename std::tuple_element<1, decltype(TypeParam())>::type;
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<T1> key = get_array<T1>(type, size);
             std::vector<T2> val = get_array<T2>(type, size);
             std::vector<T1> key_bckp = key;

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -11,6 +11,10 @@ public:
     simdsort()
     {
         std::iota(arrsize.begin(), arrsize.end(), 1);
+        arrsize.push_back(10'000);
+        arrsize.push_back(100'000);
+        arrsize.push_back(1'000'000);
+
         arrtype = {"random",
                    "constant",
                    "sorted",

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -11,9 +11,13 @@ public:
     simdsort()
     {
         std::iota(arrsize.begin(), arrsize.end(), 1);
-        arrsize.push_back(10'000);
-        arrsize.push_back(100'000);
-        arrsize.push_back(1'000'000);
+        std::iota(arrsize_long.begin(), arrsize_long.end(), 1);
+#ifdef XSS_USE_OPENMP
+        // These extended tests are only needed for the OpenMP logic
+        arrsize_long.push_back(10'000);
+        arrsize_long.push_back(100'000);
+        arrsize_long.push_back(1'000'000);
+#endif
 
         arrtype = {"random",
                    "constant",
@@ -28,6 +32,7 @@ public:
     }
     std::vector<std::string> arrtype;
     std::vector<size_t> arrsize = std::vector<size_t>(1024);
+    std::vector<size_t> arrsize_long = std::vector<size_t>(1024);
 };
 
 TYPED_TEST_SUITE_P(simdsort);
@@ -36,7 +41,7 @@ TYPED_TEST_P(simdsort, test_qsort_ascending)
 {
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
 
             // Ascending order
@@ -58,7 +63,7 @@ TYPED_TEST_P(simdsort, test_qsort_descending)
 {
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<TypeParam> basearr = get_array<TypeParam>(type, size);
 
             // Descending order


### PR DESCRIPTION
This adds OpenMP acceleration to quicksort, in addition to making some changes to the testing code. On my current testing system, this gives up to a 3x speedup, though I think more may be achieved on a stronger system.

Benchmarks:
<details>
<summary><b>10m</b></summary>

```
Comparing simdsort/random_10m (from /home/sterrettm/simd-sort/x86-simd-sort/.bench/main/builddir/benchexe) to simdsort/random_10m (from /home/sterrettm/simd-sort/x86-simd-sort/.bench/qsort-openmp/builddir/benchexe)
Benchmark                                                                       Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------------ 50815267
[simdsort/random_10m vs. simdsort/random_10m]/uint64_t_mean                  -0.6462         -0.6461     161374745      57099765     161274843      57081772
[simdsort/random_10m vs. simdsort/random_10m]/int64_t_mean                   -0.6722         -0.6720     161381007      52894903     161242920      52883775
[simdsort/random_10m vs. simdsort/random_10m]/uint32_t_mean                  -0.6683         -0.6684      76346854      25321800      76335248      25316127
[simdsort/random_10m vs. simdsort/random_10m]/int32_t_mean                   -0.6461         -0.6462      74568936      26387521      74555377      26374643
[simdsort/random_10m vs. simdsort/random_10m]/uint16_t_mean                  +0.0286         +0.0286     306422934     315196752     306379370     315156800
[simdsort/random_10m vs. simdsort/random_10m]/int16_t_mean                   +0.0159         +0.0159     308471111     313372843     308432095     313323090
[simdsort/random_10m vs. simdsort/random_10m]/float_mean                     -0.6593         -0.6593      75784101      25821957      75777886      25815941
[simdsort/random_10m vs. simdsort/random_10m]/double_mean                    -0.6613         -0.6613     140408876      47560519     140340074      47530458
OVERALL_GEOMEAN                                                              -0.5520         -0.5520             0             0             0             0
```

</details>

<details>
<summary><b>1m</b></summary>

```
Comparing simdsort/random_1m (from /home/sterrettm/simd-sort/x86-simd-sort/.bench/main/builddir/benchexe) to simdsort/random_1m (from /home/sterrettm/simd-sort/x86-simd-sort/.bench/qsort-openmp/builddir/benchexe)
Benchmark                                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_1m vs. simdsort/random_1m]/uint64_t_mean                  -0.5563         -0.5564      13892838       6163743      13893768       6162738
[simdsort/random_1m vs. simdsort/random_1m]/int64_t_mean                   -0.5439         -0.5441      13943919       6359981      13944683       6358016
[simdsort/random_1m vs. simdsort/random_1m]/uint32_t_mean                  -0.4661         -0.4662       6244794       3334286       6244370       3333435
[simdsort/random_1m vs. simdsort/random_1m]/int32_t_mean                   -0.3862         -0.3861       6172364       3788625       6173740       3789904
[simdsort/random_1m vs. simdsort/random_1m]/uint16_t_mean                  -0.0138         -0.0138      31545637      31108834      31548000      31111137
[simdsort/random_1m vs. simdsort/random_1m]/int16_t_mean                   -0.0076         -0.0076      30964472      30728775      30967064      30730877467       3261958
[simdsort/random_1m vs. simdsort/random_1m]/float_mean                     -0.4568         -0.4566       6418410       3486598       6419908       3488443
[simdsort/random_1m vs. simdsort/random_1m]/double_mean                    -0.5486         -0.5488      11469483       5177166      11469799       5174866
OVERALL_GEOMEAN                                                            -0.4088         -0.4089             0             0             0             0
```

</details>

And to show that there does not seem to be a regression with small sizes due to the SIMD logic:
<details>
<summary><b>128</b></summary>

```
Benchmark                                                                       Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_128 vs. simdsort/random_128]/uint64_t_mean                  -0.0442         -0.0512           866           828           878           833
[simdsort/random_128 vs. simdsort/random_128]/int64_t_mean                   -0.0006         -0.0028           821           821           828           826
[simdsort/random_128 vs. simdsort/random_128]/uint32_t_mean                  +0.0152         +0.0150           583           591           587           596
[simdsort/random_128 vs. simdsort/random_128]/int32_t_mean                   +0.0210         +0.0150           582           594           588           597
[simdsort/random_128 vs. simdsort/random_128]/uint16_t_mean                  -0.0034         +0.0008          1933          1926          1939          1941
[simdsort/random_128 vs. simdsort/random_128]/int16_t_mean                   +0.0061         +0.0104          1889          1901          1896          1916
[simdsort/random_128 vs. simdsort/random_128]/float_mean                     +0.0012         +0.0022           599           600           605           606
[simdsort/random_128 vs. simdsort/random_128]/double_mean                    +0.0079         +0.0086           707           712           711           717
OVERALL_GEOMEAN                                                              +0.0003         -0.0003             0             0             0             0
```

</details>

In addition, this adds larger tests for quicksort to test the OpenMP logic. Out of concern for the runtime of the test suite, I modified both these new tests and the older kv tests to only use the larger sizes for the main sort, the only one that uses OpenMP and thus needs them. I believe this should result in a noticeable net reduction in the runtime of the test suite.

