### PR TITLE
Add defensive EMMS instructions to each SIMD sort function

### DIFF
--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -572,6 +572,11 @@ avx512_qsort_fp16(uint16_t *arr,
         }
         replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 [[maybe_unused]] X86_SIMD_SORT_INLINE void
@@ -605,6 +610,11 @@ avx512_qselect_fp16(uint16_t *arr,
                     2 * (arrsize_t)log2(indx_last_elem));
         }
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 [[maybe_unused]] X86_SIMD_SORT_INLINE void

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -652,6 +652,11 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
             std::reverse(indexes, indexes + arrsize);
         }
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 template <typename T1,
@@ -712,6 +717,11 @@ X86_SIMD_SORT_INLINE void xss_select_kv(T1 *keys,
             std::reverse(indexes, indexes + arrsize);
         }
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 template <typename T1,

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -632,6 +632,11 @@ X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
 
         replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 // Quick select methods
@@ -666,6 +671,11 @@ xss_qselect(T *arr, arrsize_t k, arrsize_t arrsize, bool hasnan)
                                        index_last_elem,
                                        2 * (arrsize_t)log2(arrsize));
     }
+
+#ifdef __MMX__
+    // Workaround for compiler bug generating MMX instructions without emms
+    _mm_empty();
+#endif
 }
 
 // Partial sort methods:


### PR DESCRIPTION
Due to some compiler bug, some GCC versions, specifically GCC 9, generate MMX instructions without the required EMMS instruction. This can cause strange and obscure crashes.

A previous version of this problem caused #154, and it now seems to be causing issues with Pytorch. Out of an abundance of caution, this adds defensive EMMS intrinsics to the end of each of the SIMD sorting functions whenever MMX is enabled, to try and make sure this issue never shows up ever again.