### PR TITLE
Fix avx512fp16 build

### DIFF
--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -11,7 +11,7 @@ static int check_cpu_feature_support(std::string_view cpufeature)
 
     if ((cpufeature == "avx512_spr") && (!disable_avx512))
 #if defined(__FLT16_MAX__) && !defined(__INTEL_LLVM_COMPILER) \
-        && __clang_major__ >= 18
+        && (!defined(__clang_major__) || __clang_major__ >= 18)
         return __builtin_cpu_supports("avx512f")
                 && __builtin_cpu_supports("avx512fp16")
                 && __builtin_cpu_supports("avx512vbmi2");


### PR DESCRIPTION
Currently the avx512fp16 code is never built on GCC, because of changes made in https://github.com/intel/x86-simd-sort/commit/3bb92964fee090e7ffeb033e4cefdaf92dc32294. This should fix that by making it only check the clang version if the clang version macro is defined