### PR TITLE
Change scorecard runner to ubuntu-latest

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
   
     name: Scorecard analysis
     if: github.repository == 'intel/x86-simd-sort'
-    runs-on: intel-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
As far as I can tell, self-hosted runners are not really supported by the OSSF scorecard. It used to be on ubuntu-latest, but got changed to intel-ubuntu-24.04, which I believe is what has caused this problem. Hopefully this should fix it.