### PR TITLE
Change 16-bit swizzle from vector to C arrays

### DIFF
--- a/src/avx512-16bit-common.h
+++ b/src/avx512-16bit-common.h
@@ -14,11 +14,11 @@ struct avx512_16bit_swizzle_ops {
         __m512i v = vtype::cast_to(reg);
 
         if constexpr (scale == 2) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {1,  0,  3,  2,  5,  4,  7,  6,  9,  8,  11,
                        10, 13, 12, 15, 14, 17, 16, 19, 18, 21, 20,
                        23, 22, 25, 24, 27, 26, 29, 28, 31, 30};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 4) {
@@ -48,27 +48,27 @@ struct avx512_16bit_swizzle_ops {
 
         if constexpr (scale == 2) { return swap_n<vtype, 2>(reg); }
         else if constexpr (scale == 4) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {3,  2,  1,  0,  7,  6,  5,  4,  11, 10, 9,
                        8,  15, 14, 13, 12, 19, 18, 17, 16, 23, 22,
                        21, 20, 27, 26, 25, 24, 31, 30, 29, 28};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 8) {
-            std::vector<uint16_t> arr
+            constexpr static int16_t arr[]
                     = {7,  6,  5,  4,  3,  2,  1,  0,  15, 14, 13,
                        12, 11, 10, 9,  8,  23, 22, 21, 20, 19, 18,
                        17, 16, 31, 30, 29, 28, 27, 26, 25, 24};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 16) {
-            std::vector<uint16_t> arr
+            constexpr static uint16_t arr[]
                     = {15, 14, 13, 12, 11, 10, 9,  8,  7,  6,  5,
                        4,  3,  2,  1,  0,  31, 30, 29, 28, 27, 26,
                        25, 24, 23, 22, 21, 20, 19, 18, 17, 16};
-            __m512i mask = _mm512_loadu_si512(arr.data());
+            __m512i mask = _mm512_loadu_si512(arr);
             v = _mm512_permutexvar_epi16(mask, v);
         }
         else if constexpr (scale == 32) {


### PR DESCRIPTION
This gives around a 4x speedup for int16_t and uint16_t, and a small speedup for _Float16.
```
Benchmark                                                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_10m/ vs. simdsort/random_10m/]uint64_t                -0.0050         -0.0050      76843507      76455793      76842001      76455226
[simdsort/random_10m/ vs. simdsort/random_10m/]int64_t                 -0.0032         -0.0031      77150199      76902515      77140564      76900428
[simdsort/random_10m/ vs. simdsort/random_10m/]uint32_t                -0.0044         -0.0044      31186978      31048516      31183252      31044913
[simdsort/random_10m/ vs. simdsort/random_10m/]int32_t                 -0.0044         -0.0043      31110415      30974272      31107703      30973732
[simdsort/random_10m/ vs. simdsort/random_10m/]uint16_t                -0.7547         -0.7548     113662270      27878061     113660292      27874788
[simdsort/random_10m/ vs. simdsort/random_10m/]int16_t                 -0.7572         -0.7572     114264023      27737899     114252418      27735801
[simdsort/random_10m/ vs. simdsort/random_10m/]float                   -0.0045         -0.0045      30462857      30326576      30462539      30325958
[simdsort/random_10m/ vs. simdsort/random_10m/]double                  -0.0078         -0.0079      63941783      63443562      63939974      63432449
[simdsort/random_10m/ vs. simdsort/random_10m/]_Float16                -0.1168         -0.1168      77634297      68570359      77623152      68554958
OVERALL_GEOMEAN                                                        -0.2814         -0.2815             0             0             0             0
```