### PR TITLE
Use std::threads instead of openmp for parallelizing qsort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	meson setup -Dbuild_tests=true -Duse_openmp=false --warnlevel 2 --werror --buildtype release builddir
+	meson setup -Dbuild_tests=true -Duse_openmp=true --warnlevel 2 --werror --buildtype release builddir
 	cd builddir && ninja
 
 test_openmp:
@@ -7,7 +7,7 @@ test_openmp:
 	cd builddir && ninja
 
 bench:
-	meson setup -Dbuild_benchmarks=true --warnlevel 2 --werror --buildtype release builddir
+	meson setup -Dbuild_benchmarks=true -Duse_openmp=true --warnlevel 2 --werror --buildtype release builddir
 	cd builddir && ninja
 
 debug:

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -11,7 +11,7 @@ if [ ! -d .bench/google-benchmark ]; then
 fi
 compare=$(realpath .bench/google-benchmark/tools/compare.py)
 
-meson setup -Dbuild_benchmarks=true -Dbuild_ippbench=true --warnlevel 0 --buildtype release builddir-${branch}
+meson setup -Dbuild_benchmarks=true -Duse_openmp=true --warnlevel 0 --buildtype release builddir-${branch}
 cd builddir-${branch}
 ninja
 $compare filters ./benchexe $1 $2 --benchmark_repetitions=$3

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -9,10 +9,6 @@
 
 #include "avx512-16bit-common.h"
 
-struct float16 {
-    uint16_t val;
-};
-
 template <>
 struct zmm_vector<float16> {
     using type_t = uint16_t;
@@ -555,6 +551,7 @@ avx512_qsort_fp16(uint16_t *arr,
                   bool descending = false)
 {
     using vtype = zmm_vector<float16>;
+    struct threadmanager tm;
 
     // TODO multithreading support here
     if (arrsize > 1) {
@@ -565,11 +562,11 @@ avx512_qsort_fp16(uint16_t *arr,
         }
         if (descending) {
             qsort_<vtype, Comparator<vtype, true>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), tm);
         }
         else {
             qsort_<vtype, Comparator<vtype, false>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), tm);
         }
         replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -7,6 +7,8 @@
 #include <immintrin.h>
 #include <limits>
 #include <vector>
+#include <thread>
+#include <mutex>
 #include "xss-custom-float.h"
 
 #define X86_SIMD_SORT_INFINITY std::numeric_limits<double>::infinity()
@@ -87,6 +89,10 @@
 #include <omp.h>
 #endif
 
+struct float16 {
+    uint16_t val;
+};
+
 template <class... T>
 constexpr bool always_false = false;
 
@@ -108,5 +114,27 @@ enum class simd_type : int { AVX2, AVX512 };
 
 template <typename vtype, typename T = typename vtype::type_t>
 X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
+
+struct threadmanager {
+    int max_thread_count;
+    std::mutex mymutex;
+    int sharedCount;
+    arrsize_t task_threshold;
+
+    threadmanager() {
+#ifdef XSS_COMPILE_OPENMP
+        max_thread_count = 8;
+#else
+        max_thread_count = 0;
+#endif
+        sharedCount = 0;
+        task_threshold = 100000;
+    };
+    void incrementCount(int ii) {
+        mymutex.lock();
+        sharedCount += ii;
+        mymutex.unlock();
+    }
+};
 
 #endif // XSS_COMMON_INCLUDES


### PR DESCRIPTION
First stab at switching to std::threads to not have the dependency on openmp. These look like about 10-20% slower than the openmp version, not entirely sure why:

```
Benchmark                                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------
[simdsort/random_10m/int* vs. simdsort/random_10m/int*]64_t                +0.1881         -0.8570      36212571      43022493      36211824       5177321
[simdsort/random_10m/int* vs. simdsort/random_10m/int*]32_t                +0.1628         -0.8453      16560818      19257370      16560817       2561878
[simdsort/random_10m/int* vs. simdsort/random_10m/int*]16_t                +0.1600         -0.8628      11944131      13854631      11942415       1638489
OVERALL_GEOMEAN                                                            +0.1702         -0.8552             0             0             0             0
```