### PR TITLE
Add OpenMP support to argsort

### DIFF
--- a/benchmarks/bench-objsort.hpp
+++ b/benchmarks/bench-objsort.hpp
@@ -13,9 +13,9 @@ struct Point3D {
     static constexpr std::string_view name {val};
     Point3D()
     {
-        x = (T)rand() / RAND_MAX;
-        y = (T)rand() / RAND_MAX;
-        z = (T)rand() / RAND_MAX;
+        x = (T)rand() / (T)RAND_MAX;
+        y = (T)rand() / (T)RAND_MAX;
+        z = (T)rand() / (T)RAND_MAX;
     }
     T distance()
     {

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -640,6 +640,7 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
                                        arrsize - 1,
                                        2 * (arrsize_t)log2(arrsize),
                                        task_threshold);
+#pragma omp taskwait
         }
         else {
             argsort_<vectype, argtype>(arr,
@@ -649,7 +650,6 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
                                        2 * (arrsize_t)log2(arrsize),
                                        std::numeric_limits<arrsize_t>::max());
         }
-#pragma omp taskwait
 #else
         argsort_<vectype, argtype>(
                 arr, arg, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -472,7 +472,8 @@ X86_SIMD_SORT_INLINE void argsort_(type_t *arr,
                                    arrsize_t *arg,
                                    arrsize_t left,
                                    arrsize_t right,
-                                   arrsize_t max_iters)
+                                   arrsize_t max_iters,
+                                   arrsize_t task_threshold)
 {
     /*
      * Resort to std::sort if quicksort isnt making any progress
@@ -494,11 +495,57 @@ X86_SIMD_SORT_INLINE void argsort_(type_t *arr,
     type_t biggest = vtype::type_min();
     arrsize_t pivot_index = argpartition_unrolled<vtype, argtype, 4>(
             arr, arg, left, right + 1, pivot, &smallest, &biggest);
+#ifdef XSS_COMPILE_OPENMP
+    if (pivot != smallest) {
+        bool parallel_left = (pivot_index - left) > task_threshold;
+        if (parallel_left) {
+#pragma omp task
+            argsort_<vtype, argtype>(arr,
+                                     arg,
+                                     left,
+                                     pivot_index - 1,
+                                     max_iters - 1,
+                                     task_threshold);
+        }
+        else {
+            argsort_<vtype, argtype>(arr,
+                                     arg,
+                                     left,
+                                     pivot_index - 1,
+                                     max_iters - 1,
+                                     task_threshold);
+        }
+    }
+    if (pivot != biggest) {
+        bool parallel_right = (right - pivot_index) > task_threshold;
+
+        if (parallel_right) {
+#pragma omp task
+            argsort_<vtype, argtype>(arr,
+                                     arg,
+                                     pivot_index,
+                                     right,
+                                     max_iters - 1,
+                                     task_threshold);
+        }
+        else {
+            argsort_<vtype, argtype>(arr,
+                                     arg,
+                                     pivot_index,
+                                     right,
+                                     max_iters - 1,
+                                     task_threshold);
+        }
+    }
+#else
+    UNUSED(task_threshold);
     if (pivot != smallest)
         argsort_<vtype, argtype>(
-                arr, arg, left, pivot_index - 1, max_iters - 1);
+                arr, arg, left, pivot_index - 1, max_iters - 1, 0);
     if (pivot != biggest)
-        argsort_<vtype, argtype>(arr, arg, pivot_index, right, max_iters - 1);
+        argsort_<vtype, argtype>(
+                arr, arg, pivot_index, right, max_iters - 1, 0);
+#endif
 }
 
 template <typename vtype, typename argtype, typename type_t>
@@ -570,8 +617,43 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
             }
         }
         UNUSED(hasnan);
+
+#ifdef XSS_COMPILE_OPENMP
+
+        bool use_parallel = arrsize > 10000;
+
+        if (use_parallel) {
+            // This thread limit was determined experimentally; it may be better for it to be the number of physical cores on the system
+            constexpr int thread_limit = 8;
+            int thread_count = std::min(thread_limit, omp_get_max_threads());
+            arrsize_t task_threshold
+                    = std::max((arrsize_t)100000, arrsize / 100);
+
+            // We use omp parallel and then omp single to setup the threads that will run the omp task calls in qsort_
+            // The omp single prevents multiple threads from running the initial qsort_ simultaneously and causing problems
+            // Note that we do not use the if(...) clause built into OpenMP, because it causes a performance regression for small arrays
+#pragma omp parallel num_threads(thread_count)
+#pragma omp single
+            argsort_<vectype, argtype>(arr,
+                                       arg,
+                                       0,
+                                       arrsize - 1,
+                                       2 * (arrsize_t)log2(arrsize),
+                                       task_threshold);
+        }
+        else {
+            argsort_<vectype, argtype>(arr,
+                                       arg,
+                                       0,
+                                       arrsize - 1,
+                                       2 * (arrsize_t)log2(arrsize),
+                                       std::numeric_limits<arrsize_t>::max());
+        }
+#pragma omp taskwait
+#else
         argsort_<vectype, argtype>(
-                arr, arg, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize));
+                arr, arg, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+#endif
 
         if (descending) { std::reverse(arg, arg + arrsize); }
     }

--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -627,7 +627,7 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
             constexpr int thread_limit = 8;
             int thread_count = std::min(thread_limit, omp_get_max_threads());
             arrsize_t task_threshold
-                    = std::max((arrsize_t)100000, arrsize / 100);
+                    = std::max((arrsize_t)10000, arrsize / 100);
 
             // We use omp parallel and then omp single to setup the threads that will run the omp task calls in qsort_
             // The omp single prevents multiple threads from running the initial qsort_ simultaneously and causing problems

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -627,6 +627,7 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
                                       index_last_elem,
                                       maxiters,
                                       task_threshold);
+#pragma omp taskwait
         }
         else {
             kvsort_<keytype, valtype>(keys,
@@ -636,7 +637,6 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
                                       maxiters,
                                       std::numeric_limits<arrsize_t>::max());
         }
-#pragma omp taskwait
 #else
         kvsort_<keytype, valtype>(
                 keys, indexes, 0, index_last_elem, maxiters, 0);

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -682,6 +682,7 @@ X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
                                          arrsize - 1,
                                          2 * (arrsize_t)log2(arrsize),
                                          task_threshold);
+#pragma omp taskwait
         }
         else {
             qsort_<vtype, comparator, T>(arr,
@@ -690,7 +691,6 @@ X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
                                          2 * (arrsize_t)log2(arrsize),
                                          std::numeric_limits<arrsize_t>::max());
         }
-#pragma omp taskwait
 #else
         qsort_<vtype, comparator, T>(
                 arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -89,7 +89,7 @@ TYPED_TEST_P(simdsort, test_argsort_ascending)
 {
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
             std::vector<TypeParam> sortedarr = arr;
 
@@ -110,7 +110,7 @@ TYPED_TEST_P(simdsort, test_argsort_descending)
 {
     for (auto type : this->arrtype) {
         bool hasnan = is_nan_test(type);
-        for (auto size : this->arrsize) {
+        for (auto size : this->arrsize_long) {
             std::vector<TypeParam> arr = get_array<TypeParam>(type, size);
             std::vector<TypeParam> sortedarr = arr;
 


### PR DESCRIPTION
This patch adds OpenMP support to argsort, in much the same way as quicksort and key-value sort.
Smaller benchmark sizes are included to show that there is not a significant regression for those smaller sizes.
<details>
<summary><b>128/100k/1m/10m/100m Benchmarks</b></summary>

```
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort/random_128/* vs. simdargsort/random_128/*]int64_t                 -0.0066         -0.0060           538           534           537           534
[simdargsort/random_128/* vs. simdargsort/random_128/*]uint64_t                +0.0038         +0.0042           538           540           538           540
[simdargsort/random_128/* vs. simdargsort/random_128/*]double                  +0.0068         +0.0072           398           401           398           401
[simdargsort/random_128/* vs. simdargsort/random_128/*]int32_t                 -0.0081         -0.0075           377           374           377           374
[simdargsort/random_128/* vs. simdargsort/random_128/*]uint32_t                -0.0072         -0.0070           378           375           378           375
[simdargsort/random_128/* vs. simdargsort/random_128/*]float                   -0.0427         -0.0425           405           388           405           388
OVERALL_GEOMEAN                                                                -0.0091         -0.0087             0             0             0             0

Benchmark                                                                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]int64_t                 -0.6343         -0.6343       1328931        486040       1328908        485967
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]uint64_t                -0.6199         -0.6200       1332846        506636       1332837        506521
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]double                  -0.6506         -0.6506       1216462        425010       1216343        424938
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]int32_t                 -0.6073         -0.6074       1159372        455239       1159356        455141
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]uint32_t                -0.6264         -0.6265       1136127        424415       1136070        424348
[simdargsort/random_100k/* vs. simdargsort/random_100k/*]float                   -0.6114         -0.6115       1173640        456028       1173632        455971
OVERALL_GEOMEAN                                                                  -0.6253         -0.6253             0             0             0             0

Benchmark                                                                       Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]int64_t                 -0.7172         -0.7173      24256168       6858762      24256005       6858362
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]uint64_t                -0.7142         -0.7142      23993105       6856463      23992567       6856165
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]double                  -0.7372         -0.7373      22509499       5914566      22509178       5914256
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]int32_t                 -0.7338         -0.7338      19369104       5156914      19368839       5156653
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]uint32_t                -0.7386         -0.7386      19365743       5062443      19364946       5061877
[simdargsort/random_1m/* vs. simdargsort/random_1m/*]float                   -0.7682         -0.7682      19175104       4445467      19173415       4444931
OVERALL_GEOMEAN                                                              -0.7355         -0.7355             0             0             0             0

Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]int64_t                 -0.7188         -0.7206     535672018     150621678     535662039     149682185
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]uint64_t                -0.7123         -0.7137     522665977     150358943     522662888     149658818
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]double                  -0.7063         -0.7067     516422888     151683883     516408490     151469114
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]int32_t                 -0.7343         -0.7345     421554181     112011550     421499972     111900516
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]uint32_t                -0.7383         -0.7384     421089877     110216843     421017197     110153338
[simdargsort/random_10m/* vs. simdargsort/random_10m/*]float                   -0.7343         -0.7343     422777178     112339041     422770468     112336650
OVERALL_GEOMEAN                                                                -0.7243         -0.7249             0             0             0             0

Benchmark                                                                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------------
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]int64_t                 -0.6427         -0.6708   11788397461    4211981148   11787561815    3880782867
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]uint64_t                -0.6655         -0.6686   11836971450    3959080747   11835896648    3922945957
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]double                  -0.6655         -0.6728   11628384117    3889522807   11627635685    3804081330
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]int32_t                 -0.6790         -0.6848    9693999063    3111721408    9693378022    3054949141
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]uint32_t                -0.6809         -0.6844    9680041695    3088878433    9679286446    3055234564
[simdargsort/random_100m/* vs. simdargsort/random_100m/*]float                   -0.6852         -0.7007    9624159505    3030112691    9623024906    2879783882
OVERALL_GEOMEAN                                                                  -0.6701         -0.6805            11             4            11             3
```

</details>
