### PR TITLE
Add Meson dependency declaration for use as a subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ benchmark](https://github.com/google/benchmark) frameworks respectively. You
 can configure meson to build them both by using `-Dbuild_tests=true` and
 `-Dbuild_benchmarks=true`.
 
+## Using x86-simd-sort as a Meson subproject
+
+If you would like to use this as a Meson subproject, then create `subprojects`
+directory and copy `x86-simd-sort` into it. Add these two lines
+in your meson.build.
+```
+xss = subproject('x86-simd-sort')
+xss_dep = xss.get_variable('x86simdsortcpp_dep')
+```
+
+For more detailed instructions please refer to Meson
+[documentation](https://mesonbuild.com/Subprojects.html#using-a-subproject).
+
 ## Example usage
 
 #### Sort an array of floats

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,11 @@ else
                             )
 endif
 
+x86simdsortcpp_dep = declare_dependency(
+  include_directories: include_directories('lib'),
+  link_with: libsimdsort,
+)
+
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(libraries : libsimdsort,
                  version : '4.0',

--- a/meson.build
+++ b/meson.build
@@ -61,11 +61,6 @@ else
                             )
 endif
 
-x86simdsortcpp_dep = declare_dependency(
-  include_directories: include_directories('lib'),
-  link_with: libsimdsort,
-)
-
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(libraries : libsimdsort,
                  version : '4.0',
@@ -73,15 +68,20 @@ pkg_mod.generate(libraries : libsimdsort,
                  filebase : 'x86simdsortcpp',
                  description : 'C++ template library for high performance SIMD based sorting routines.')
 
+# Create a new dependency variable making it easy to use this as a subproject:
+x86simdsortcpp_dep = declare_dependency(
+  include_directories: include_directories('lib'),
+  link_with: libsimdsort,
+)
+
 # Build test suite if option build_tests set to true
 if get_option('build_tests')
   gtest_dep = dependency('gtest_main', required : true, static: false)
   subdir('tests')
   testexe = executable('testexe',
                      include_directories : [lib, utils],
-                     dependencies : gtest_dep,
+                     dependencies : [gtest_dep, x86simdsortcpp_dep],
                      link_whole : [libtests],
-                     link_with : libsimdsort,
                     )
   test('x86 simd sort tests', testexe)
 endif
@@ -94,10 +94,9 @@ if get_option('build_benchmarks')
   subdir('benchmarks')
   benchexe = executable('benchexe',
                       include_directories : [src, lib, utils, bench],
-                      dependencies : [gbench_dep, thread_dep],
+                      dependencies : [gbench_dep, thread_dep, x86simdsortcpp_dep],
                       link_args: ['-lbenchmark_main', ipplink],
                       link_whole : [libbench],
-                      link_with : libsimdsort,
                      )
 endif
 


### PR DESCRIPTION
Added a `declare_dependency` call to `meson.build`, allowing the library to be more easily used as a Meson subproject.