### PR TITLE
Enable fp16 nonnative support for dynamic dispatch, make more ergonomic for static dispatch

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -208,6 +208,9 @@ jobs:
 
     - name: Run test suite on SPR
       run: sde -spr -- ./builddir/testexe
+    - name: Run ICL fp16 tests
+      # Note: This filters for the _Float16 tests based on the number assigned to it, which could change in the future
+      run: sde -icx -- ./builddir/testexe --gtest_filter="*/simdsort/2*"
 
   SKX-SKL-openmp:
 

--- a/lib/x86simdsort-icl.cpp
+++ b/lib/x86simdsort-icl.cpp
@@ -50,5 +50,30 @@ namespace avx512 {
     {
         x86simdsortStatic::partial_qsort(arr, k, arrsize, hasnan, descending);
     }
+#ifdef __FLT16_MAX__
+    template <>
+    void qsort(_Float16 *arr, size_t size, bool hasnan, bool descending)
+    {
+        x86simdsortStatic::qsort(arr, size, hasnan, descending);
+    }
+    template <>
+    void qselect(_Float16 *arr,
+                 size_t k,
+                 size_t arrsize,
+                 bool hasnan,
+                 bool descending)
+    {
+        x86simdsortStatic::qselect(arr, k, arrsize, hasnan, descending);
+    }
+    template <>
+    void partial_qsort(_Float16 *arr,
+                       size_t k,
+                       size_t arrsize,
+                       bool hasnan,
+                       bool descending)
+    {
+        x86simdsortStatic::partial_qsort(arr, k, arrsize, hasnan, descending);
+    }
+#endif
 } // namespace avx512
 } // namespace xss

--- a/lib/x86simdsort-icl.cpp
+++ b/lib/x86simdsort-icl.cpp
@@ -50,6 +50,8 @@ namespace avx512 {
     {
         x86simdsortStatic::partial_qsort(arr, k, arrsize, hasnan, descending);
     }
+} // namespace avx512
+namespace fp16_icl {
 #ifdef __FLT16_MAX__
     template <>
     void qsort(_Float16 *arr, size_t size, bool hasnan, bool descending)
@@ -75,5 +77,5 @@ namespace avx512 {
         x86simdsortStatic::partial_qsort(arr, k, arrsize, hasnan, descending);
     }
 #endif
-} // namespace avx512
+} // namespace fp16_icl
 } // namespace xss

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -4,205 +4,58 @@
 #include <stdint.h>
 #include <vector>
 
+#define DECLAREALLFUNCS(name) \
+    namespace name { \
+    template <typename T> \
+    XSS_HIDE_SYMBOL void \
+    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false); \
+    template <typename T1, typename T2> \
+    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key, \
+                                        T2 *val, \
+                                        size_t arrsize, \
+                                        bool hasnan = false, \
+                                        bool descending = false); \
+    template <typename T> \
+    XSS_HIDE_SYMBOL void qselect(T *arr, \
+                                 size_t k, \
+                                 size_t arrsize, \
+                                 bool hasnan = false, \
+                                 bool descending = false); \
+    template <typename T1, typename T2> \
+    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key, \
+                                         T2 *val, \
+                                         size_t k, \
+                                         size_t arrsize, \
+                                         bool hasnan = false, \
+                                         bool descending = false); \
+    template <typename T> \
+    XSS_HIDE_SYMBOL void partial_qsort(T *arr, \
+                                       size_t k, \
+                                       size_t arrsize, \
+                                       bool hasnan = false, \
+                                       bool descending = false); \
+    template <typename T1, typename T2> \
+    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key, \
+                                               T2 *val, \
+                                               size_t k, \
+                                               size_t arrsize, \
+                                               bool hasnan = false, \
+                                               bool descending = false); \
+    template <typename T> \
+    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr, \
+                                                size_t arrsize, \
+                                                bool hasnan = false, \
+                                                bool descending = false); \
+    template <typename T> \
+    XSS_HIDE_SYMBOL std::vector<size_t> \
+    argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false); \
+    } \
+
 namespace xss {
-namespace avx512 {
-    // quicksort
-    template <typename T>
-    XSS_HIDE_SYMBOL void
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
-    // key-value quicksort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
-                                        T2 *val,
-                                        size_t arrsize,
-                                        bool hasnan = false,
-                                        bool descending = false);
-    // quickselect
-    template <typename T>
-    XSS_HIDE_SYMBOL void qselect(T *arr,
-                                 size_t k,
-                                 size_t arrsize,
-                                 bool hasnan = false,
-                                 bool descending = false);
-    // key-value select
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
-                                         T2 *val,
-                                         size_t k,
-                                         size_t arrsize,
-                                         bool hasnan = false,
-                                         bool descending = false);
-    // partial sort
-    template <typename T>
-    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
-                                       size_t k,
-                                       size_t arrsize,
-                                       bool hasnan = false,
-                                       bool descending = false);
-    // key-value partial sort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
-                                               T2 *val,
-                                               size_t k,
-                                               size_t arrsize,
-                                               bool hasnan = false,
-                                               bool descending = false);
-    // argsort
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
-                                                size_t arrsize,
-                                                bool hasnan = false,
-                                                bool descending = false);
-    // argselect
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
-} // namespace avx512
-namespace avx2 {
-    // quicksort
-    template <typename T>
-    XSS_HIDE_SYMBOL void
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
-    // key-value quicksort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
-                                        T2 *val,
-                                        size_t arrsize,
-                                        bool hasnan = false,
-                                        bool descending = false);
-    // quickselect
-    template <typename T>
-    XSS_HIDE_SYMBOL void qselect(T *arr,
-                                 size_t k,
-                                 size_t arrsize,
-                                 bool hasnan = false,
-                                 bool descending = false);
-    // key-value select
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
-                                         T2 *val,
-                                         size_t k,
-                                         size_t arrsize,
-                                         bool hasnan = false,
-                                         bool descending = false);
-    // partial sort
-    template <typename T>
-    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
-                                       size_t k,
-                                       size_t arrsize,
-                                       bool hasnan = false,
-                                       bool descending = false);
-    // key-value partial sort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
-                                               T2 *val,
-                                               size_t k,
-                                               size_t arrsize,
-                                               bool hasnan = false,
-                                               bool descending = false);
-    // argsort
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
-                                                size_t arrsize,
-                                                bool hasnan = false,
-                                                bool descending = false);
-    // argselect
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
-} // namespace avx2
-namespace scalar {
-    // quicksort
-    template <typename T>
-    XSS_HIDE_SYMBOL void
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
-    // key-value quicksort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key,
-                                        T2 *val,
-                                        size_t arrsize,
-                                        bool hasnan = false,
-                                        bool descending = false);
-    // quickselect
-    template <typename T>
-    XSS_HIDE_SYMBOL void qselect(T *arr,
-                                 size_t k,
-                                 size_t arrsize,
-                                 bool hasnan = false,
-                                 bool descending = false);
-    // key-value select
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_select(T1 *key,
-                                         T2 *val,
-                                         size_t k,
-                                         size_t arrsize,
-                                         bool hasnan = false,
-                                         bool descending = false);
-    // partial sort
-    template <typename T>
-    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
-                                       size_t k,
-                                       size_t arrsize,
-                                       bool hasnan = false,
-                                       bool descending = false);
-    // key-value partial sort
-    template <typename T1, typename T2>
-    XSS_HIDE_SYMBOL void keyvalue_partial_sort(T1 *key,
-                                               T2 *val,
-                                               size_t k,
-                                               size_t arrsize,
-                                               bool hasnan = false,
-                                               bool descending = false);
-    // argsort
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t> argsort(T *arr,
-                                                size_t arrsize,
-                                                bool hasnan = false,
-                                                bool descending = false);
-    // argselect
-    template <typename T>
-    XSS_HIDE_SYMBOL std::vector<size_t>
-    argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
-} // namespace scalar
-namespace fp16_spr {
-    // quicksort
-    template <typename T>
-    XSS_HIDE_SYMBOL void
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
-    // quickselect
-    template <typename T>
-    XSS_HIDE_SYMBOL void qselect(T *arr,
-                                 size_t k,
-                                 size_t arrsize,
-                                 bool hasnan = false,
-                                 bool descending = false);
-    // partial sort
-    template <typename T>
-    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
-                                       size_t k,
-                                       size_t arrsize,
-                                       bool hasnan = false,
-                                       bool descending = false);
-} // namespace fp16_spr
-namespace fp16_icl {
-    // quicksort
-    template <typename T>
-    XSS_HIDE_SYMBOL void
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
-    // quickselect
-    template <typename T>
-    XSS_HIDE_SYMBOL void qselect(T *arr,
-                                 size_t k,
-                                 size_t arrsize,
-                                 bool hasnan = false,
-                                 bool descending = false);
-    // partial sort
-    template <typename T>
-    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
-                                       size_t k,
-                                       size_t arrsize,
-                                       bool hasnan = false,
-                                       bool descending = false);
-} // namespace fp16_icl
+    DECLAREALLFUNCS(avx512)
+    DECLAREALLFUNCS(avx2)
+    DECLAREALLFUNCS(scalar)
+    DECLAREALLFUNCS(fp16_spr)
+    DECLAREALLFUNCS(fp16_icl)
 } // namespace xss
 #endif

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -7,8 +7,10 @@
 #define DECLAREALLFUNCS(name) \
     namespace name { \
     template <typename T> \
-    XSS_HIDE_SYMBOL void \
-    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false); \
+    XSS_HIDE_SYMBOL void qsort(T *arr, \
+                               size_t arrsize, \
+                               bool hasnan = false, \
+                               bool descending = false); \
     template <typename T1, typename T2> \
     XSS_HIDE_SYMBOL void keyvalue_qsort(T1 *key, \
                                         T2 *val, \
@@ -49,13 +51,13 @@
     template <typename T> \
     XSS_HIDE_SYMBOL std::vector<size_t> \
     argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false); \
-    } \
+    }
 
 namespace xss {
-    DECLAREALLFUNCS(avx512)
-    DECLAREALLFUNCS(avx2)
-    DECLAREALLFUNCS(scalar)
-    DECLAREALLFUNCS(fp16_spr)
-    DECLAREALLFUNCS(fp16_icl)
+DECLAREALLFUNCS(avx512)
+DECLAREALLFUNCS(avx2)
+DECLAREALLFUNCS(scalar)
+DECLAREALLFUNCS(fp16_spr)
+DECLAREALLFUNCS(fp16_icl)
 } // namespace xss
 #endif

--- a/lib/x86simdsort-internal.h
+++ b/lib/x86simdsort-internal.h
@@ -164,5 +164,45 @@ namespace scalar {
     XSS_HIDE_SYMBOL std::vector<size_t>
     argselect(T *arr, size_t k, size_t arrsize, bool hasnan = false);
 } // namespace scalar
+namespace fp16_spr {
+    // quicksort
+    template <typename T>
+    XSS_HIDE_SYMBOL void
+    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
+    // quickselect
+    template <typename T>
+    XSS_HIDE_SYMBOL void qselect(T *arr,
+                                 size_t k,
+                                 size_t arrsize,
+                                 bool hasnan = false,
+                                 bool descending = false);
+    // partial sort
+    template <typename T>
+    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
+                                       size_t k,
+                                       size_t arrsize,
+                                       bool hasnan = false,
+                                       bool descending = false);
+} // namespace fp16_spr
+namespace fp16_icl {
+    // quicksort
+    template <typename T>
+    XSS_HIDE_SYMBOL void
+    qsort(T *arr, size_t arrsize, bool hasnan = false, bool descending = false);
+    // quickselect
+    template <typename T>
+    XSS_HIDE_SYMBOL void qselect(T *arr,
+                                 size_t k,
+                                 size_t arrsize,
+                                 bool hasnan = false,
+                                 bool descending = false);
+    // partial sort
+    template <typename T>
+    XSS_HIDE_SYMBOL void partial_qsort(T *arr,
+                                       size_t k,
+                                       size_t arrsize,
+                                       bool hasnan = false,
+                                       bool descending = false);
+} // namespace fp16_icl
 } // namespace xss
 #endif

--- a/lib/x86simdsort-spr.cpp
+++ b/lib/x86simdsort-spr.cpp
@@ -3,7 +3,7 @@
 #include "x86simdsort-internal.h"
 
 namespace xss {
-namespace avx512 {
+namespace fp16_spr {
     template <>
     void qsort(_Float16 *arr, size_t size, bool hasnan, bool descending)
     {
@@ -27,5 +27,5 @@ namespace avx512 {
     {
         x86simdsortStatic::partial_qsort(arr, k, arrsize, hasnan, descending);
     }
-} // namespace avx512
+} // namespace fp16_spr
 } // namespace xss

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -130,6 +130,27 @@ namespace x86simdsort {
         } \
     }
 
+#define DISPATCH_FP16(func, TYPE, ISA) \
+    DECLARE_INTERNAL_##func(TYPE) static __attribute__((constructor)) void \
+    CAT(CAT(resolve_, func), TYPE)(void) \
+    { \
+        CAT(CAT(internal_, func), TYPE) = &xss::scalar::func<TYPE>; \
+        __builtin_cpu_init(); \
+        std::string_view preferred_cpu = find_preferred_cpu(ISA); \
+        if constexpr (dispatch_requested("avx512_spr", ISA)) { \
+            if (preferred_cpu.find("avx512_spr") != std::string_view::npos) { \
+                CAT(CAT(internal_, func), TYPE) = &xss::fp16_spr::func<TYPE>; \
+                return; \
+            } \
+        } \
+        if constexpr (dispatch_requested("avx512_icl", ISA)) { \
+            if (preferred_cpu.find("avx512_icl") != std::string_view::npos) { \
+                CAT(CAT(internal_, func), TYPE) = &xss::fp16_icl::func<TYPE>; \
+                return; \
+            } \
+        } \
+    }
+
 #define ISA_LIST(...) \
     std::initializer_list<std::string_view> \
     { \
@@ -137,9 +158,9 @@ namespace x86simdsort {
     }
 
 #ifdef __FLT16_MAX__
-DISPATCH(qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
-DISPATCH(qselect, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
-DISPATCH(partial_qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
+DISPATCH_FP16(qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
+DISPATCH_FP16(qselect, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
+DISPATCH_FP16(partial_qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
 DISPATCH(argsort, _Float16, ISA_LIST("none"))
 DISPATCH(argselect, _Float16, ISA_LIST("none"))
 #endif

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -137,9 +137,9 @@ namespace x86simdsort {
     }
 
 #ifdef __FLT16_MAX__
-DISPATCH(qsort, _Float16, ISA_LIST("avx512_spr"))
-DISPATCH(qselect, _Float16, ISA_LIST("avx512_spr"))
-DISPATCH(partial_qsort, _Float16, ISA_LIST("avx512_spr"))
+DISPATCH(qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
+DISPATCH(qselect, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
+DISPATCH(partial_qsort, _Float16, ISA_LIST("avx512_spr", "avx512_icl"))
 DISPATCH(argsort, _Float16, ISA_LIST("none"))
 DISPATCH(argselect, _Float16, ISA_LIST("none"))
 #endif

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -119,18 +119,23 @@ namespace x86simdsort {
         if constexpr (dispatch_requested("avx512", ISA)) { \
             if (preferred_cpu.find("avx512") != std::string_view::npos) { \
                 if constexpr (std::is_same_v<TYPE, _Float16>) { \
-                    if (preferred_cpu.find("avx512_spr") != std::string_view::npos) { \
-                        CAT(CAT(internal_, func), TYPE) = &xss::fp16_spr::func<TYPE>; \
+                    if (preferred_cpu.find("avx512_spr") \
+                        != std::string_view::npos) { \
+                        CAT(CAT(internal_, func), TYPE) \
+                                = &xss::fp16_spr::func<TYPE>; \
                         return; \
                     } \
-                    if (preferred_cpu.find("avx512_icl") != std::string_view::npos) { \
-                        CAT(CAT(internal_, func), TYPE) = &xss::fp16_icl::func<TYPE>; \
+                    if (preferred_cpu.find("avx512_icl") \
+                        != std::string_view::npos) { \
+                        CAT(CAT(internal_, func), TYPE) \
+                                = &xss::fp16_icl::func<TYPE>; \
                         return; \
                     } \
                 } \
                 else { \
-                    CAT(CAT(internal_, func), TYPE) = &xss::avx512::func<TYPE>; \
-                }\
+                    CAT(CAT(internal_, func), TYPE) \
+                            = &xss::avx512::func<TYPE>; \
+                } \
                 return; \
             } \
         } \

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -541,28 +541,6 @@ replace_nan_with_inf<zmm_vector<float16>>(uint16_t *arr, arrsize_t arrsize)
     return nan_count;
 }
 
-X86_SIMD_SORT_INLINE_ONLY void replace_inf_with_nan_fp16(float16 *arr,
-                                                         arrsize_t size,
-                                                         arrsize_t nan_count,
-                                                         bool descending
-                                                         = false)
-{
-    constexpr float16 quiet_NaN = {0x7c01};
-
-    if (descending) {
-        for (arrsize_t ii = 0; nan_count > 0; ++ii) {
-            arr[ii] = quiet_NaN;
-            nan_count -= 1;
-        }
-    }
-    else {
-        for (arrsize_t ii = size - 1; nan_count > 0; --ii) {
-            arr[ii] = quiet_NaN;
-            nan_count -= 1;
-        }
-    }
-}
-
 template <typename comparator>
 [[maybe_unused]] X86_SIMD_SORT_INLINE void
 avx512_qsort_fp16_helper(uint16_t *arr, arrsize_t arrsize)
@@ -623,8 +601,7 @@ avx512_qsort_fp16(uint16_t *arr,
         else {
             avx512_qsort_fp16_helper<Comparator<vtype, false>>(arr, arrsize);
         }
-        replace_inf_with_nan_fp16(
-                (float16 *)arr, arrsize, nan_count, descending);
+        replace_inf_with_nan(arr, arrsize, nan_count, descending);
     }
 
 #ifdef __MMX__

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -541,21 +541,23 @@ replace_nan_with_inf<zmm_vector<float16>>(uint16_t *arr, arrsize_t arrsize)
     return nan_count;
 }
 
-X86_SIMD_SORT_INLINE_ONLY void replace_inf_with_nan_fp16(_Float16 *arr,
+X86_SIMD_SORT_INLINE_ONLY void replace_inf_with_nan_fp16(float16 *arr,
                                                          arrsize_t size,
                                                          arrsize_t nan_count,
                                                          bool descending
                                                          = false)
 {
+    constexpr float16 quiet_NaN = {0x7c01};
+
     if (descending) {
         for (arrsize_t ii = 0; nan_count > 0; ++ii) {
-            arr[ii] = xss::fp::quiet_NaN<_Float16>();
+            arr[ii] = quiet_NaN;
             nan_count -= 1;
         }
     }
     else {
         for (arrsize_t ii = size - 1; nan_count > 0; --ii) {
-            arr[ii] = xss::fp::quiet_NaN<_Float16>();
+            arr[ii] = quiet_NaN;
             nan_count -= 1;
         }
     }
@@ -622,7 +624,7 @@ avx512_qsort_fp16(uint16_t *arr,
             avx512_qsort_fp16_helper<Comparator<vtype, false>>(arr, arrsize);
         }
         replace_inf_with_nan_fp16(
-                (_Float16 *)arr, arrsize, nan_count, descending);
+                (float16 *)arr, arrsize, nan_count, descending);
     }
 
 #ifdef __MMX__

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -9,10 +9,6 @@
 
 #include "avx512-16bit-common.h"
 
-struct float16 {
-    uint16_t val;
-};
-
 template <>
 struct zmm_vector<float16> {
     using type_t = uint16_t;
@@ -545,10 +541,65 @@ replace_nan_with_inf<zmm_vector<float16>>(uint16_t *arr, arrsize_t arrsize)
     return nan_count;
 }
 
-template <>
-X86_SIMD_SORT_INLINE_ONLY bool is_a_nan<uint16_t>(uint16_t elem)
+X86_SIMD_SORT_INLINE_ONLY void replace_inf_with_nan_fp16(_Float16 *arr,
+                                                         arrsize_t size,
+                                                         arrsize_t nan_count,
+                                                         bool descending
+                                                         = false)
 {
-    return ((elem & 0x7c00u) == 0x7c00u) && ((elem & 0x03ffu) != 0);
+    if (descending) {
+        for (arrsize_t ii = 0; nan_count > 0; ++ii) {
+            arr[ii] = xss::fp::quiet_NaN<_Float16>();
+            nan_count -= 1;
+        }
+    }
+    else {
+        for (arrsize_t ii = size - 1; nan_count > 0; --ii) {
+            arr[ii] = xss::fp::quiet_NaN<_Float16>();
+            nan_count -= 1;
+        }
+    }
+}
+
+template <typename comparator>
+[[maybe_unused]] X86_SIMD_SORT_INLINE void
+avx512_qsort_fp16_helper(uint16_t *arr, arrsize_t arrsize)
+{
+    using T = uint16_t;
+    using vtype = zmm_vector<float16>;
+
+#ifdef XSS_COMPILE_OPENMP
+    bool use_parallel = arrsize > 100000;
+
+    if (use_parallel) {
+        // This thread limit was determined experimentally; it may be better for it to be the number of physical cores on the system
+        constexpr int thread_limit = 8;
+        int thread_count = std::min(thread_limit, omp_get_max_threads());
+        arrsize_t task_threshold = std::max((arrsize_t)100000, arrsize / 100);
+
+        // We use omp parallel and then omp single to setup the threads that will run the omp task calls in qsort_
+        // The omp single prevents multiple threads from running the initial qsort_ simultaneously and causing problems
+        // Note that we do not use the if(...) clause built into OpenMP, because it causes a performance regression for small arrays
+#pragma omp parallel num_threads(thread_count)
+#pragma omp single
+        qsort_<vtype, comparator, T>(arr,
+                                     0,
+                                     arrsize - 1,
+                                     2 * (arrsize_t)log2(arrsize),
+                                     task_threshold);
+    }
+    else {
+        qsort_<vtype, comparator, T>(arr,
+                                     0,
+                                     arrsize - 1,
+                                     2 * (arrsize_t)log2(arrsize),
+                                     std::numeric_limits<arrsize_t>::max());
+    }
+#pragma omp taskwait
+#else
+    qsort_<vtype, comparator, T>(
+            arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+#endif
 }
 
 [[maybe_unused]] X86_SIMD_SORT_INLINE void
@@ -559,22 +610,19 @@ avx512_qsort_fp16(uint16_t *arr,
 {
     using vtype = zmm_vector<float16>;
 
-    // TODO multithreading support here
     if (arrsize > 1) {
         arrsize_t nan_count = 0;
         if (UNLIKELY(hasnan)) {
-            nan_count = replace_nan_with_inf<zmm_vector<float16>, uint16_t>(
-                    arr, arrsize);
+            nan_count = replace_nan_with_inf<vtype, uint16_t>(arr, arrsize);
         }
         if (descending) {
-            qsort_<vtype, Comparator<vtype, true>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+            avx512_qsort_fp16_helper<Comparator<vtype, true>>(arr, arrsize);
         }
         else {
-            qsort_<vtype, Comparator<vtype, false>, uint16_t>(
-                    arr, 0, arrsize - 1, 2 * (arrsize_t)log2(arrsize), 0);
+            avx512_qsort_fp16_helper<Comparator<vtype, false>>(arr, arrsize);
         }
-        replace_inf_with_nan(arr, arrsize, nan_count, descending);
+        replace_inf_with_nan_fp16(
+                (_Float16 *)arr, arrsize, nan_count, descending);
     }
 
 #ifdef __MMX__
@@ -592,26 +640,37 @@ avx512_qselect_fp16(uint16_t *arr,
 {
     using vtype = zmm_vector<float16>;
 
-    arrsize_t indx_last_elem = arrsize - 1;
+    // Exit early if no work would be done
+    if (arrsize <= 1) return;
+
+    arrsize_t index_first_elem = 0;
+    arrsize_t index_last_elem = arrsize - 1;
+
     if (UNLIKELY(hasnan)) {
-        indx_last_elem = move_nans_to_end_of_array(arr, arrsize);
+        if (descending) {
+            index_first_elem = move_nans_to_start_of_array(arr, arrsize);
+        }
+        else {
+            index_last_elem = move_nans_to_end_of_array(arr, arrsize);
+        }
     }
-    if (indx_last_elem >= k) {
+
+    if (index_first_elem <= k && index_last_elem >= k) {
         if (descending) {
             qselect_<vtype, Comparator<vtype, true>, uint16_t>(
                     arr,
                     k,
-                    0,
-                    indx_last_elem,
-                    2 * (arrsize_t)log2(indx_last_elem));
+                    index_first_elem,
+                    index_last_elem,
+                    2 * (arrsize_t)log2(arrsize));
         }
         else {
             qselect_<vtype, Comparator<vtype, false>, uint16_t>(
                     arr,
                     k,
-                    0,
-                    indx_last_elem,
-                    2 * (arrsize_t)log2(indx_last_elem));
+                    index_first_elem,
+                    index_last_elem,
+                    2 * (arrsize_t)log2(arrsize));
         }
     }
 
@@ -628,7 +687,8 @@ avx512_partial_qsort_fp16(uint16_t *arr,
                           bool hasnan = false,
                           bool descending = false)
 {
+    if (k == 0) return;
     avx512_qselect_fp16(arr, k - 1, arrsize, hasnan, descending);
-    avx512_qsort_fp16(arr, k - 1, descending);
+    avx512_qsort_fp16(arr, k - 1, hasnan, descending);
 }
 #endif // AVX512_QSORT_16BIT

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -173,24 +173,27 @@ X86_SIMD_SORT_FINLINE void keyvalue_partial_sort(T1 *key,
 
 XSS_METHODS(avx512)
 
-#if defined(__FLT16_MAX__) && defined(__AVX512BW__) && defined(__AVX512VBMI2__) && !defined(__AVX512FP16__)
+#if defined(__FLT16_MAX__) && defined(__AVX512BW__) \
+        && defined(__AVX512VBMI2__) && !defined(__AVX512FP16__)
 template <>
-void x86simdsortStatic::qsort<_Float16>(
-		_Float16 *arr, size_t size, bool hasnan, bool descending)
+void x86simdsortStatic::qsort<_Float16>(_Float16 *arr,
+                                        size_t size,
+                                        bool hasnan,
+                                        bool descending)
 {
-	avx512_qsort_fp16((uint16_t *)arr, size, hasnan, descending);
+    avx512_qsort_fp16((uint16_t *)arr, size, hasnan, descending);
 }
 template <>
 void x86simdsortStatic::qselect<_Float16>(
-		_Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
+        _Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
 {
-	avx512_qselect_fp16((uint16_t *)arr, k, size, hasnan, descending);
+    avx512_qselect_fp16((uint16_t *)arr, k, size, hasnan, descending);
 }
 template <>
 void x86simdsortStatic::partial_qsort<_Float16>(
-		_Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
+        _Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
 {
-	avx512_partial_qsort_fp16((uint16_t *)arr, k, size, hasnan, descending);
+    avx512_partial_qsort_fp16((uint16_t *)arr, k, size, hasnan, descending);
 }
 #endif
 

--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -173,6 +173,27 @@ X86_SIMD_SORT_FINLINE void keyvalue_partial_sort(T1 *key,
 
 XSS_METHODS(avx512)
 
+#if defined(__FLT16_MAX__) && defined(__AVX512BW__) && defined(__AVX512VBMI2__) && !defined(__AVX512FP16__)
+template <>
+void x86simdsortStatic::qsort<_Float16>(
+		_Float16 *arr, size_t size, bool hasnan, bool descending)
+{
+	avx512_qsort_fp16((uint16_t *)arr, size, hasnan, descending);
+}
+template <>
+void x86simdsortStatic::qselect<_Float16>(
+		_Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
+{
+	avx512_qselect_fp16((uint16_t *)arr, k, size, hasnan, descending);
+}
+template <>
+void x86simdsortStatic::partial_qsort<_Float16>(
+		_Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
+{
+	avx512_partial_qsort_fp16((uint16_t *)arr, k, size, hasnan, descending);
+}
+#endif
+
 #elif defined(__AVX512F__)
 #error "x86simdsort requires AVX512DQ and AVX512VL to be enabled in addition to AVX512F to use AVX512"
 

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -109,4 +109,8 @@ enum class simd_type : int { AVX2, AVX512 };
 template <typename vtype, typename T = typename vtype::type_t>
 X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
 
+struct float16 {
+    uint16_t val;
+};
+
 #endif // XSS_COMMON_INCLUDES

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -116,7 +116,7 @@ X86_SIMD_SORT_INLINE void replace_inf_with_nan(type_t *arr,
                 arr[ii] = xss::fp::quiet_NaN<type_t>();
             }
             else {
-                arr[ii] = 0xFFFF;
+                arr[ii] = 0x7c01; // std::quiet_nan
             }
             nan_count -= 1;
         }
@@ -127,7 +127,7 @@ X86_SIMD_SORT_INLINE void replace_inf_with_nan(type_t *arr,
                 arr[ii] = xss::fp::quiet_NaN<type_t>();
             }
             else {
-                arr[ii] = 0xFFFF;
+                arr[ii] = 0x7c01; // std::quiet_nan
             }
             nan_count -= 1;
         }

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -45,6 +45,12 @@ bool is_a_nan(T elem)
     return std::isnan(elem);
 }
 
+template <>
+X86_SIMD_SORT_INLINE_ONLY bool is_a_nan<uint16_t>(uint16_t elem)
+{
+    return ((elem & 0x7c00u) == 0x7c00u) && ((elem & 0x03ffu) != 0);
+}
+
 template <typename vtype, typename T>
 X86_SIMD_SORT_INLINE arrsize_t replace_nan_with_inf(T *arr, arrsize_t size)
 {

--- a/tests/test-qsort.cpp
+++ b/tests/test-qsort.cpp
@@ -305,8 +305,8 @@ REGISTER_TYPED_TEST_SUITE_P(simdsort,
 
 using QSortTestTypes = testing::Types<uint16_t,
                                       int16_t,
-// support for _Float16 is incomplete in gcc-12
-#if __GNUC__ >= 13
+// support for _Float16 is incomplete in gcc-12, clang < 6
+#if __GNUC__ >= 13 || __clang_major__ >= 6
                                       _Float16,
 #endif
                                       float,


### PR DESCRIPTION
This patch enabled the non-avx512fp16 _Float16 sorting to be used by the dynamic dispatch logic, as well as integrating it better into the static dispatch logic.
It is vastly faster than scalar, but a fair bit slower then the dedicated avx512fp16 code.

<details>
<summary><b>Comparison to scalar</b></summary>

```
Benchmark                                                       Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9264         -0.9269          6368           468          6373           466
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9399         -0.9394         13394           804         13401           813
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9412         -0.9410         29552          1737         29560          1745
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9209         -0.9208         75451          5967         75463          5975
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9396         -0.9396        590828         35676        590792         35680
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9524         -0.9524      14506782        689933      14506540        689943
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9616         -0.9616     159229801       6113740     159217432       6113529
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9827         -0.9827    1739044872      30113868    1738990462      30113349
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9864         -0.9864   19075697953     259558909   19074535929     259512766
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9210         -0.9209          5579           441          5582           442
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9388         -0.9382         13171           806         13176           815
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9377         -0.9372         28020          1746         28025          1761
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9328         -0.9326         74876          5029         74879          5045
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9469         -0.9469        585484         31094        585483         31107
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9510         -0.9510      14291316        700636      14290814        700538
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9608         -0.9608     156622769       6146373     156621600       6145706
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9826         -0.9826    1729001307      30128303    1728922542      30127689
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9210         -0.9210        803746         63496        803743         63504
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9989         -0.9989        621695           656        621626           654
[scalarsort.*_Float16 vs. simdsort.*_Float16]                -0.9131         -0.9130        742937         64595        742908         64605
[scalarsort.*_Float16 vs. simdsort.*_Float16]_pvalue          0.0315          0.0315      U Test, Repetitions: 20 vs 20
OVERALL_GEOMEAN                                              -0.9595         -0.9595             0             0             0             0

```

</details>
<details>
<summary><b>Comparison to AVX512_FP16</b></summary>

```
Benchmark                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.6382         +0.6557           269           441           268           443
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.3411         +0.3500           604           810           605           816
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.7145         +0.7192          1014          1739          1017          1748
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.7644         +1.7643          2153          5951          2156          5959
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.8787         +1.8783         12278         35344         12282         35351
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.7758         +0.7759        385721        684977        385712        684986
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.3700         +0.3698       1368168       1874386       1368250       1874260
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.4479         +0.4479       5137910       7438989       5137603       7438745
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.1682         +0.1652      77774693      90857847      77385351      90173137
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.6533         +0.6521           267           441           268           442
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.3211         +0.3280           612           809           613           814
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.5179         +0.5210          1141          1732          1143          1738
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.6678         +1.6679          2200          5868          2202          5876
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.5668         +1.5672         12788         32824         12788         32830
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.7579         +0.7581        384179        675344        384134        675354
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.2080         +0.2081       1552580       1875503       1552298       1875373
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.4877         +0.4877       5052821       7516986       5052579       7516805
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.4458         +1.4462         25727         62922         25727         62934
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +0.5392         +0.5407           445           685           445           686
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]                +1.4454         +1.4455         25703         62854         25705         62862
[.*simdsort.*_Float16 vs. .*simdsort.*_Float16]_pvalue          0.5075          0.5075      U Test, Repetitions: 20 vs 20
OVERALL_GEOMEAN                                                +0.7601         +0.7624             0             0             0             0

```

</details>