### PR TITLE
Try to get better type errors for the static sorting functions

### DIFF
--- a/src/xss-common-argsort.h
+++ b/src/xss-common-argsort.h
@@ -584,6 +584,14 @@ X86_SIMD_SORT_INLINE void argselect_(type_t *arr,
                 arr, arg, pos, pivot_index, right, max_iters - 1);
 }
 
+template <typename T, typename vtype>
+X86_SIMD_SORT_FINLINE bool is_sorted(T *arr, arrsize_t arrsize, bool descending)
+{
+    auto comp = descending ? Comparator<vtype, true>::STDSortComparator
+                           : Comparator<vtype, false>::STDSortComparator;
+    return std::is_sorted(arr, arr + arrsize, comp);
+}
+
 /* argsort methods for 32-bit and 64-bit dtypes */
 template <typename T,
           template <typename...>
@@ -600,11 +608,12 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
     using vectype = typename std::conditional<sizeof(T) == sizeof(int32_t),
                                               half_vector<T>,
                                               full_vector<T>>::type;
-
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       half_vector<arrsize_t>,
                                       full_vector<arrsize_t>>::type;
+    static_assert(is_valid_vector_type_key_value<vectype, argtype>(),
+                  "Invalid type for argsort!");
 
     if (arrsize > 1) {
         /* simdargsort does not work for float/double arrays with nan */
@@ -620,9 +629,7 @@ X86_SIMD_SORT_INLINE void xss_argsort(T *arr,
         UNUSED(hasnan);
 
         /* early exit for already sorted arrays: float/double with nan never reach here*/
-        auto comp = descending ? Comparator<vectype, true>::STDSortComparator
-                               : Comparator<vectype, false>::STDSortComparator;
-        if (std::is_sorted(arr, arr + arrsize, comp)) { return; }
+        if (is_sorted<T, vectype>(arr, arrsize, descending)) { return; }
 
 #ifdef XSS_COMPILE_OPENMP
 
@@ -708,11 +715,12 @@ X86_SIMD_SORT_INLINE void xss_argselect(T *arr,
     using vectype = typename std::conditional<sizeof(T) == sizeof(int32_t),
                                               half_vector<T>,
                                               full_vector<T>>::type;
-
     using argtype =
             typename std::conditional<sizeof(arrsize_t) == sizeof(int32_t),
                                       half_vector<arrsize_t>,
                                       full_vector<arrsize_t>>::type;
+    static_assert(is_valid_vector_type_key_value<vectype, argtype>(),
+                  "Invalid type for argselect!");
 
     if (arrsize > 1) {
         if constexpr (xss::fp::is_floating_point_v<T>) {

--- a/src/xss-common-includes.h
+++ b/src/xss-common-includes.h
@@ -92,19 +92,27 @@ constexpr bool always_false = false;
 
 typedef size_t arrsize_t;
 
-template <typename type>
-struct zmm_vector;
+enum class simd_type : int { INVALID, AVX2, AVX512 };
 
 template <typename type>
-struct ymm_vector;
+struct zmm_vector {
+    static constexpr simd_type vec_type = simd_type::INVALID;
+};
 
 template <typename type>
-struct avx2_vector;
+struct ymm_vector {
+    static constexpr simd_type vec_type = simd_type::INVALID;
+};
 
 template <typename type>
-struct avx2_half_vector;
+struct avx2_vector {
+    static constexpr simd_type vec_type = simd_type::INVALID;
+};
 
-enum class simd_type : int { AVX2, AVX512 };
+template <typename type>
+struct avx2_half_vector {
+    static constexpr simd_type vec_type = simd_type::INVALID;
+};
 
 template <typename vtype, typename T = typename vtype::type_t>
 X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
@@ -112,5 +120,30 @@ X86_SIMD_SORT_INLINE bool comparison_func(const T &a, const T &b);
 struct float16 {
     uint16_t val;
 };
+
+template <typename vtype>
+constexpr bool is_valid_vector_type()
+{
+    return vtype::vec_type != simd_type::INVALID;
+}
+
+template <typename vtype>
+constexpr bool is_valid_vector_type_32_or_64_bit()
+{
+    if constexpr (is_valid_vector_type<vtype>()) {
+        constexpr int type_size = sizeof(typename vtype::type_t);
+        return type_size == 4 || type_size == 8;
+    }
+    else {
+        return false;
+    }
+}
+
+template <typename vtype1, typename vtype2>
+constexpr bool is_valid_vector_type_key_value()
+{
+    return is_valid_vector_type_32_or_64_bit<vtype1>()
+            && is_valid_vector_type_32_or_64_bit<vtype2>();
+}
 
 #endif // XSS_COMMON_INCLUDES

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -580,6 +580,8 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
                                               && sizeof(T2) == sizeof(int32_t),
                                       half_vector<T2>,
                                       full_vector<T2>>::type;
+    static_assert(is_valid_vector_type_key_value<keytype, valtype>(),
+                  "Invalid type for keyvalue_qsort!");
 
     // Exit early if no work would be done
     if (arrsize <= 1) return;
@@ -677,6 +679,8 @@ X86_SIMD_SORT_INLINE void xss_select_kv(T1 *keys,
                                               && sizeof(T2) == sizeof(int32_t),
                                       half_vector<T2>,
                                       full_vector<T2>>::type;
+    static_assert(is_valid_vector_type_key_value<keytype, valtype>(),
+                  "Invalid type for keyvalue_select!");
 
     // Exit early if no work would be done
     if (arrsize <= 1) return;
@@ -732,6 +736,19 @@ X86_SIMD_SORT_INLINE void xss_partial_sort_kv(T1 *keys,
                                               bool hasnan,
                                               bool descending)
 {
+    using keytype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T1) == sizeof(int32_t),
+                                      half_vector<T1>,
+                                      full_vector<T1>>::type;
+    using valtype =
+            typename std::conditional<sizeof(T1) != sizeof(T2)
+                                              && sizeof(T2) == sizeof(int32_t),
+                                      half_vector<T2>,
+                                      full_vector<T2>>::type;
+    static_assert(is_valid_vector_type_key_value<keytype, valtype>(),
+                  "Invalid type for keyvalue_partial_sort!");
+
     if (k == 0) return;
     xss_select_kv<T1, T2, full_vector, half_vector>(
             keys, indexes, k - 1, arrsize, hasnan, descending);

--- a/src/xss-common-qsort.h
+++ b/src/xss-common-qsort.h
@@ -652,6 +652,7 @@ X86_SIMD_SORT_INLINE void qselect_(type_t *arr,
 template <typename vtype, typename T, bool descending = false>
 X86_SIMD_SORT_INLINE void xss_qsort(T *arr, arrsize_t arrsize, bool hasnan)
 {
+    static_assert(is_valid_vector_type<vtype>(), "Invalid type for qsort!");
     using comparator =
             typename std::conditional<descending,
                                       Comparator<vtype, true>,
@@ -716,6 +717,7 @@ template <typename vtype, typename T, bool descending = false>
 X86_SIMD_SORT_INLINE void
 xss_qselect(T *arr, arrsize_t k, arrsize_t arrsize, bool hasnan)
 {
+    static_assert(is_valid_vector_type<vtype>(), "Invalid type for qselect!");
     using comparator =
             typename std::conditional<descending,
                                       Comparator<vtype, true>,
@@ -758,6 +760,8 @@ template <typename vtype, typename T, bool descending = false>
 X86_SIMD_SORT_INLINE void
 xss_partial_qsort(T *arr, arrsize_t k, arrsize_t arrsize, bool hasnan)
 {
+    static_assert(is_valid_vector_type<vtype>(),
+                  "Invalid type for partial_qsort!");
     if (k == 0) return;
     xss_qselect<vtype, T, descending>(arr, k - 1, arrsize, hasnan);
     xss_qsort<vtype, T, descending>(arr, k - 1, hasnan);


### PR DESCRIPTION
This patch tries to make type errors better when building with the static functions. It should hopefully make it more clear when the typing is an issue.

Here is a comparison between before and after error messages for GCC with a simple test program that tries to sort int16_t values. This is built with only AVX2 enabled, so int16_t sorting is not available. 
 
<details>
<summary><b>GCC Before</b></summary>

```
In file included from ../x86-simd-sort/src/xss-pivot-selection.hpp:5,
                 from ../x86-simd-sort/src/xss-common-qsort.h:37,
                 from ../x86-simd-sort/src/x86simdsort-static-incl.h:155,
                 from main.cpp:2:
../x86-simd-sort/src/xss-common-comparators.hpp: In instantiation of ‘struct Comparator<avx2_vector<short int>, true>’:
../x86-simd-sort/src/xss-common-qsort.h:540:60:   required from ‘void qsort_(type_t*, arrsize_t, arrsize_t, arrsize_t, arrsize_t) [with vtype = avx2_vector<short int>; comparator = Comparator<avx2_vector<short int>, true>; type_t = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:701:37:   required from ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = true; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:806:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-comparators.hpp:39:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   39 |     using reg_t = typename vtype::reg_t;
      |           ^~~~~
In file included from ../x86-simd-sort/src/x86simdsort-static-incl.h:5:
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-comparators.hpp:40:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   40 |     using opmask_t = typename vtype::opmask_t;
      |           ^~~~~~~~
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-comparators.hpp:41:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   41 |     using type_t = typename vtype::type_t;
      |           ^~~~~~
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h: In instantiation of ‘void qsort_(type_t*, arrsize_t, arrsize_t, arrsize_t, arrsize_t) [with vtype = avx2_vector<short int>; comparator = Comparator<avx2_vector<short int>, true>; type_t = short int; arrsize_t = long unsigned int]’:
../x86-simd-sort/src/xss-common-qsort.h:701:37:   required from ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = true; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:806:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-qsort.h:540:60: error: ‘STDSortComparator’ is not a member of ‘Comparator<avx2_vector<short int>, true>’
  540 |         std::sort(arr + left, arr + right + 1, comparator::STDSortComparator);
      |                                                            ^~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:546:36: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  546 |     if (right + 1 - left <= vtype::network_sort_threshold) {
      |                                    ^~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:547:42: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  547 |         sort_n<vtype, comparator, vtype::network_sort_threshold>(
      |                                          ^~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:558:38: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  558 |     type_t smallest = vtype::type_max();
      |                       ~~~~~~~~~~~~~~~^~
../x86-simd-sort/src/xss-common-qsort.h:559:37: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  559 |     type_t biggest = vtype::type_min();
      |                      ~~~~~~~~~~~~~~~^~
../x86-simd-sort/src/xss-common-qsort.h:563:55: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  563 |                                                vtype::partition_unroll_factor>(
      |                                                       ^~~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:568:48: error: ‘leftmost’ is not a member of ‘Comparator<avx2_vector<short int>, true>’
  568 |     type_t leftmostValue = comparator::leftmost(smallest, biggest);
      |                            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:569:50: error: ‘rightmost’ is not a member of ‘Comparator<avx2_vector<short int>, true>’
  569 |     type_t rightmostValue = comparator::rightmost(smallest, biggest);
      |                             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-comparators.hpp: In instantiation of ‘struct Comparator<avx2_vector<short int>, false>’:
../x86-simd-sort/src/xss-common-qsort.h:540:60:   required from ‘void qsort_(type_t*, arrsize_t, arrsize_t, arrsize_t, arrsize_t) [with vtype = avx2_vector<short int>; comparator = Comparator<avx2_vector<short int>, false>; type_t = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:701:37:   required from ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = false; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:806:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-comparators.hpp:39:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   39 |     using reg_t = typename vtype::reg_t;
      |           ^~~~~
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-comparators.hpp:40:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   40 |     using opmask_t = typename vtype::opmask_t;
      |           ^~~~~~~~
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-comparators.hpp:41:11: error: invalid use of incomplete type ‘struct avx2_vector<short int>’
   41 |     using type_t = typename vtype::type_t;
      |           ^~~~~~
../x86-simd-sort/src/xss-common-includes.h:102:8: note: declaration of ‘struct avx2_vector<short int>’
  102 | struct avx2_vector;
      |        ^~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h: In instantiation of ‘void qsort_(type_t*, arrsize_t, arrsize_t, arrsize_t, arrsize_t) [with vtype = avx2_vector<short int>; comparator = Comparator<avx2_vector<short int>, false>; type_t = short int; arrsize_t = long unsigned int]’:
../x86-simd-sort/src/xss-common-qsort.h:701:37:   required from ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = false; arrsize_t = long unsigned int]’
../x86-simd-sort/src/xss-common-qsort.h:806:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-qsort.h:540:60: error: ‘STDSortComparator’ is not a member of ‘Comparator<avx2_vector<short int>, false>’
  540 |         std::sort(arr + left, arr + right + 1, comparator::STDSortComparator);
      |                                                            ^~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:546:36: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  546 |     if (right + 1 - left <= vtype::network_sort_threshold) {
      |                                    ^~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:547:42: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  547 |         sort_n<vtype, comparator, vtype::network_sort_threshold>(
      |                                          ^~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:558:38: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  558 |     type_t smallest = vtype::type_max();
      |                       ~~~~~~~~~~~~~~~^~
../x86-simd-sort/src/xss-common-qsort.h:559:37: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  559 |     type_t biggest = vtype::type_min();
      |                      ~~~~~~~~~~~~~~~^~
../x86-simd-sort/src/xss-common-qsort.h:563:55: error: incomplete type ‘avx2_vector<short int>’ used in nested name specifier
  563 |                                                vtype::partition_unroll_factor>(
      |                                                       ^~~~~~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:568:48: error: ‘leftmost’ is not a member of ‘Comparator<avx2_vector<short int>, false>’
  568 |     type_t leftmostValue = comparator::leftmost(smallest, biggest);
      |                            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
../x86-simd-sort/src/xss-common-qsort.h:569:50: error: ‘rightmost’ is not a member of ‘Comparator<avx2_vector<short int>, false>’
  569 |     type_t rightmostValue = comparator::rightmost(smallest, biggest);
      |                             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~

```

</details>
<details>
<summary><b>GCC After</b></summary>

```
In file included from ../x86-simd-sort/src/x86simdsort-static-incl.h:155,
                 from main.cpp:2:
../x86-simd-sort/src/xss-common-qsort.h: In instantiation of ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = true; arrsize_t = long unsigned int]’:
../x86-simd-sort/src/xss-common-qsort.h:810:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-qsort.h:655:46: error: static assertion failed: Invalid type for qsort!
  655 |     static_assert(is_valid_vector_type<vtype>(), "Invalid type for qsort!");
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
../x86-simd-sort/src/xss-common-qsort.h:655:46: note: ‘is_valid_vector_type<avx2_vector<short int> >()’ evaluates to false
../x86-simd-sort/src/xss-common-qsort.h: In instantiation of ‘void xss_qsort(T*, arrsize_t, bool) [with vtype = avx2_vector<short int>; T = short int; bool descending = false; arrsize_t = long unsigned int]’:
../x86-simd-sort/src/xss-common-qsort.h:810:1:   required from ‘void avx2_qsort(T*, arrsize_t, bool, bool) [with T = short int; arrsize_t = long unsigned int]’
../x86-simd-sort/src/x86simdsort-static-incl.h:208:1:   required from ‘void x86simdsortStatic::qsort(T*, size_t, bool, bool) [with T = short int; size_t = long unsigned int]’
main.cpp:15:29:   required from here
../x86-simd-sort/src/xss-common-qsort.h:655:46: error: static assertion failed: Invalid type for qsort!
../x86-simd-sort/src/xss-common-qsort.h:655:46: note: ‘is_valid_vector_type<avx2_vector<short int> >()’ evaluates to false

```

</details>

Unfortunately, it doesn't work nearly as well for Clang:

<details>
<summary><b>Clang Before</b></summary>

```
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:39:28: error: implicit instantiation of undefined template 'avx2_vector<short>'
   39 |     using reg_t = typename vtype::reg_t;
      |                            ^
./../x86-simd-sort/src/xss-common-qsort.h:540:48: note: in instantiation of template class 'Comparator<avx2_vector<short>, true>' requested here
  540 |         std::sort(arr + left, arr + right + 1, comparator::STDSortComparator);
      |                                                ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:40:31: error: implicit instantiation of undefined template 'avx2_vector<short>'
   40 |     using opmask_t = typename vtype::opmask_t;
      |                               ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:41:29: error: implicit instantiation of undefined template 'avx2_vector<short>'
   41 |     using type_t = typename vtype::type_t;
      |                             ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:546:29: error: implicit instantiation of undefined template 'avx2_vector<short>'
  546 |     if (right + 1 - left <= vtype::network_sort_threshold) {
      |                             ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:558:23: error: implicit instantiation of undefined template 'avx2_vector<short>'
  558 |     type_t smallest = vtype::type_max();
      |                       ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:559:22: error: implicit instantiation of undefined template 'avx2_vector<short>'
  559 |     type_t biggest = vtype::type_min();
      |                      ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:563:48: error: implicit instantiation of undefined template 'avx2_vector<short>'
  563 |                                                vtype::partition_unroll_factor>(
      |                                                ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:98:28: error: implicit instantiation of undefined template 'avx2_vector<short>'
   98 |     using reg_t = typename vtype::reg_t;
      |                            ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:101:43: error: implicit instantiation of undefined template 'avx2_vector<short>'
  101 |     if (right - left + 1 <= 4 * numVecs * vtype::numlanes) {
      |                                           ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:105:33: error: implicit instantiation of undefined template 'avx2_vector<short>'
  105 |     constexpr int N = numVecs * vtype::numlanes;
      |                                 ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:107:32: error: implicit instantiation of undefined template 'avx2_vector<short>'
  107 |     arrsize_t width = (right - vtype::numlanes) - left;
      |                                ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:112:19: error: implicit instantiation of undefined template 'avx2_vector<short>'
  112 |         vecs[i] = vtype::loadu(arr + left + delta * i);
      |                   ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:122:9: error: implicit instantiation of undefined template 'avx2_vector<short>'
  122 |         vtype::storeu(samples + vtype::numlanes * i, vecs[i]);
      |         ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:39:28: error: implicit instantiation of undefined template 'avx2_vector<short>'
   39 |     using reg_t = typename vtype::reg_t;
      |                            ^
./../x86-simd-sort/src/xss-optimal-networks.hpp:9:5: note: in instantiation of template class 'Comparator<avx2_vector<short>, false>' requested here
    9 |     comparator::COEX(vecs[0], vecs[2]);
      |     ^
./../x86-simd-sort/src/xss-network-qsort.hpp:23:9: note: in instantiation of function template specialization 'optimal_sort_4<avx2_vector<short>, Comparator<avx2_vector<short>, false>, int>' requested here
   23 |         optimal_sort_4<vtype, comparator>(regs);
      |         ^
./../x86-simd-sort/src/xss-network-qsort.hpp:165:5: note: in instantiation of function template specialization 'bitonic_sort_n_vec<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  165 |     bitonic_sort_n_vec<vtype, comparator, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-pivot-selection.hpp:118:5: note: in instantiation of function template specialization 'sort_vectors<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  118 |     sort_vectors<vtype, Comparator<vtype, false>, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:40:31: error: implicit instantiation of undefined template 'avx2_vector<short>'
   40 |     using opmask_t = typename vtype::opmask_t;
      |                               ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:41:29: error: implicit instantiation of undefined template 'avx2_vector<short>'
   41 |     using type_t = typename vtype::type_t;
      |                             ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:195:9: error: implicit instantiation of undefined template 'avx2_vector<short>'
  195 |     a = vtype::min(a, b);
      |         ^
./../x86-simd-sort/src/xss-common-comparators.hpp:64:15: note: in instantiation of function template specialization 'COEX<avx2_vector<short>, int>' requested here
   64 |             ::COEX<vtype, reg_t>(a, b);
      |               ^
./../x86-simd-sort/src/xss-optimal-networks.hpp:10:17: note: in instantiation of member function 'Comparator<avx2_vector<short>, false>::COEX' requested here
   10 |     comparator::COEX(vecs[1], vecs[3]);
      |                 ^
./../x86-simd-sort/src/xss-network-qsort.hpp:23:9: note: in instantiation of function template specialization 'optimal_sort_4<avx2_vector<short>, Comparator<avx2_vector<short>, false>, int>' requested here
   23 |         optimal_sort_4<vtype, comparator>(regs);
      |         ^
./../x86-simd-sort/src/xss-network-qsort.hpp:165:5: note: in instantiation of function template specialization 'bitonic_sort_n_vec<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  165 |     bitonic_sort_n_vec<vtype, comparator, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-pivot-selection.hpp:118:5: note: in instantiation of function template specialization 'sort_vectors<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  118 |     sort_vectors<vtype, Comparator<vtype, false>, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:196:9: error: implicit instantiation of undefined template 'avx2_vector<short>'
  196 |     b = vtype::max(temp, b);
      |         ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:4:
./../x86-simd-sort/src/xss-network-qsort.hpp:146:28: error: implicit instantiation of undefined template 'avx2_vector<short>'
  146 |     if constexpr (numPer > vtype::numlanes) {
      |                            ^
./../x86-simd-sort/src/xss-network-qsort.hpp:168:5: note: in instantiation of function template specialization 'merge_n_vec<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, 2, int>' requested here
  168 |     merge_n_vec<vtype, comparator, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-pivot-selection.hpp:118:5: note: in instantiation of function template specialization 'sort_vectors<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  118 |     sort_vectors<vtype, Comparator<vtype, false>, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:701:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  701 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:806:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  806 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:773:27: note: expanded from macro 'DEFINE_METHODS'
  773 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:164:1: note: expanded from here
  164 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
./../x86-simd-sort/src/xss-common-includes.h:102:8: note: template is declared here
  102 | struct avx2_vector;
      |        ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.

```

</details>
<details>
<summary><b>Clang After</b></summary>

```
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:655:19: error: static assertion failed due to requirement 'is_valid_vector_type<avx2_vector<short>>()': Invalid type for qsort!
  655 |     static_assert(is_valid_vector_type<vtype>(), "Invalid type for qsort!");
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:39:35: error: no type named 'reg_t' in 'avx2_vector<short>'
   39 |     using reg_t = typename vtype::reg_t;
      |                   ~~~~~~~~~~~~~~~~^~~~~
./../x86-simd-sort/src/xss-common-qsort.h:540:48: note: in instantiation of template class 'Comparator<avx2_vector<short>, true>' requested here
  540 |         std::sort(arr + left, arr + right + 1, comparator::STDSortComparator);
      |                                                ^
./../x86-simd-sort/src/xss-common-qsort.h:702:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  702 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:40:38: error: no type named 'opmask_t' in 'avx2_vector<short>'
   40 |     using opmask_t = typename vtype::opmask_t;
      |                      ~~~~~~~~~~~~~~~~^~~~~~~~
./../x86-simd-sort/src/xss-common-comparators.hpp:41:36: error: no type named 'type_t' in 'avx2_vector<short>'
   41 |     using type_t = typename vtype::type_t;
      |                    ~~~~~~~~~~~~~~~~^~~~~~
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:546:36: error: no member named 'network_sort_threshold' in 'avx2_vector<short>'
  546 |     if (right + 1 - left <= vtype::network_sort_threshold) {
      |                             ~~~~~~~^
./../x86-simd-sort/src/xss-common-qsort.h:702:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  702 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:558:30: error: no member named 'type_max' in 'avx2_vector<short>'
  558 |     type_t smallest = vtype::type_max();
      |                       ~~~~~~~^
./../x86-simd-sort/src/xss-common-qsort.h:559:29: error: no member named 'type_min' in 'avx2_vector<short>'
  559 |     type_t biggest = vtype::type_min();
      |                      ~~~~~~~^
./../x86-simd-sort/src/xss-common-qsort.h:563:55: error: no member named 'partition_unroll_factor' in 'avx2_vector<short>'
  563 |                                                vtype::partition_unroll_factor>(
      |                                                ~~~~~~~^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:98:35: error: no type named 'reg_t' in 'avx2_vector<short>'
   98 |     using reg_t = typename vtype::reg_t;
      |                   ~~~~~~~~~~~~~~~~^~~~~
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:702:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  702 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
./../x86-simd-sort/src/xss-pivot-selection.hpp:101:50: error: no member named 'numlanes' in 'avx2_vector<short>'
  101 |     if (right - left + 1 <= 4 * numVecs * vtype::numlanes) {
      |                                           ~~~~~~~^
./../x86-simd-sort/src/xss-pivot-selection.hpp:105:40: error: no member named 'numlanes' in 'avx2_vector<short>'
  105 |     constexpr int N = numVecs * vtype::numlanes;
      |                                 ~~~~~~~^
./../x86-simd-sort/src/xss-pivot-selection.hpp:107:39: error: no member named 'numlanes' in 'avx2_vector<short>'
  107 |     arrsize_t width = (right - vtype::numlanes) - left;
      |                                ~~~~~~~^
./../x86-simd-sort/src/xss-pivot-selection.hpp:112:26: error: no member named 'loadu' in 'avx2_vector<short>'
  112 |         vecs[i] = vtype::loadu(arr + left + delta * i);
      |                   ~~~~~~~^
./../x86-simd-sort/src/xss-pivot-selection.hpp:122:16: error: no member named 'storeu' in 'avx2_vector<short>'
  122 |         vtype::storeu(samples + vtype::numlanes * i, vecs[i]);
      |         ~~~~~~~^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:39:35: error: no type named 'reg_t' in 'avx2_vector<short>'
   39 |     using reg_t = typename vtype::reg_t;
      |                   ~~~~~~~~~~~~~~~~^~~~~
./../x86-simd-sort/src/xss-optimal-networks.hpp:9:5: note: in instantiation of template class 'Comparator<avx2_vector<short>, false>' requested here
    9 |     comparator::COEX(vecs[0], vecs[2]);
      |     ^
./../x86-simd-sort/src/xss-network-qsort.hpp:23:9: note: in instantiation of function template specialization 'optimal_sort_4<avx2_vector<short>, Comparator<avx2_vector<short>, false>, int>' requested here
   23 |         optimal_sort_4<vtype, comparator>(regs);
      |         ^
./../x86-simd-sort/src/xss-network-qsort.hpp:165:5: note: in instantiation of function template specialization 'bitonic_sort_n_vec<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  165 |     bitonic_sort_n_vec<vtype, comparator, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-pivot-selection.hpp:118:5: note: in instantiation of function template specialization 'sort_vectors<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  118 |     sort_vectors<vtype, Comparator<vtype, false>, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:702:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  702 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
In file included from ./../x86-simd-sort/src/xss-common-qsort.h:37:
In file included from ./../x86-simd-sort/src/xss-pivot-selection.hpp:5:
./../x86-simd-sort/src/xss-common-comparators.hpp:40:38: error: no type named 'opmask_t' in 'avx2_vector<short>'
   40 |     using opmask_t = typename vtype::opmask_t;
      |                      ~~~~~~~~~~~~~~~~^~~~~~~~
./../x86-simd-sort/src/xss-common-comparators.hpp:41:36: error: no type named 'type_t' in 'avx2_vector<short>'
   41 |     using type_t = typename vtype::type_t;
      |                    ~~~~~~~~~~~~~~~~^~~~~~
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:195:16: error: no member named 'min' in 'avx2_vector<short>'
  195 |     a = vtype::min(a, b);
      |         ~~~~~~~^
./../x86-simd-sort/src/xss-common-comparators.hpp:64:15: note: in instantiation of function template specialization 'COEX<avx2_vector<short>, int>' requested here
   64 |             ::COEX<vtype, reg_t>(a, b);
      |               ^
./../x86-simd-sort/src/xss-optimal-networks.hpp:10:17: note: in instantiation of member function 'Comparator<avx2_vector<short>, false>::COEX' requested here
   10 |     comparator::COEX(vecs[1], vecs[3]);
      |                 ^
./../x86-simd-sort/src/xss-network-qsort.hpp:23:9: note: in instantiation of function template specialization 'optimal_sort_4<avx2_vector<short>, Comparator<avx2_vector<short>, false>, int>' requested here
   23 |         optimal_sort_4<vtype, comparator>(regs);
      |         ^
./../x86-simd-sort/src/xss-network-qsort.hpp:165:5: note: in instantiation of function template specialization 'bitonic_sort_n_vec<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  165 |     bitonic_sort_n_vec<vtype, comparator, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-pivot-selection.hpp:118:5: note: in instantiation of function template specialization 'sort_vectors<avx2_vector<short>, Comparator<avx2_vector<short>, false>, 4, int>' requested here
  118 |     sort_vectors<vtype, Comparator<vtype, false>, numVecs>(vecs);
      |     ^
./../x86-simd-sort/src/xss-common-qsort.h:553:15: note: in instantiation of function template specialization 'get_pivot_smart<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  553 |             = get_pivot_smart<vtype, comparator, type_t>(arr, left, right);
      |               ^
./../x86-simd-sort/src/xss-common-qsort.h:702:9: note: in instantiation of function template specialization 'qsort_<avx2_vector<short>, Comparator<avx2_vector<short>, true>, short>' requested here
  702 |         qsort_<vtype, comparator, T>(
      |         ^
./../x86-simd-sort/src/xss-common-qsort.h:810:1: note: in instantiation of function template specialization 'xss_qsort<avx2_vector<short>, short, true>' requested here
  810 | DEFINE_METHODS(avx2, avx2_vector<T>)
      | ^
./../x86-simd-sort/src/xss-common-qsort.h:777:27: note: expanded from macro 'DEFINE_METHODS'
  777 |         if (descending) { xss_qsort<VTYPE, T, true>(arr, size, hasnan); } \
      |                           ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:208:1: note: in instantiation of function template specialization 'avx2_qsort<short>' requested here
  208 | XSS_METHODS(avx2)
      | ^
./../x86-simd-sort/src/x86simdsort-static-incl.h:78:9: note: expanded from macro 'XSS_METHODS'
   78 |         ISA##_qsort(arr, size, hasnan, descending); \
      |         ^
<scratch space>:166:1: note: expanded from here
  166 | avx2_qsort
      | ^
main.cpp:15:24: note: in instantiation of function template specialization 'x86simdsortStatic::qsort<short>' requested here
   15 |     x86simdsortStatic::qsort(arr.data(), 34, ARRSIZE);
      |                        ^
In file included from main.cpp:2:
In file included from ./../x86-simd-sort/src/x86simdsort-static-incl.h:155:
./../x86-simd-sort/src/xss-common-qsort.h:196:16: error: no member named 'max' in 'avx2_vector<short>'
  196 |     b = vtype::max(temp, b);
      |         ~~~~~~~^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.

```

</details>

I'm not so sure about the description for the error messages, so I'd be glad to get feedback on that.