### PR TITLE
Prep for v7.0 and refactor openMP build flags

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,19 +1,14 @@
 libtargets = []
 
-# Add compile flags for OpenMP if enabled
-openmpflags = []
-if get_option('use_openmp')
-  openmpflags = ['-DXSS_USE_OPENMP=true', '-fopenmp']
-endif
-
 if cpp.has_argument('-march=haswell')
   libtargets += static_library('libavx',
     files(
       'x86simdsort-avx2.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=haswell', openmpflags],
+    cpp_args : ['-march=haswell'],
     gnu_symbol_visibility : 'inlineshidden',
+    dependencies: [omp_dep],
     )
 endif
 
@@ -23,8 +18,9 @@ if cpp.has_argument('-march=skylake-avx512')
       'x86simdsort-skx.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=skylake-avx512', openmpflags],
+    cpp_args : ['-march=skylake-avx512'],
     gnu_symbol_visibility : 'inlineshidden',
+    dependencies: [omp_dep],
     )
 endif
 
@@ -34,8 +30,9 @@ if cpp.has_argument('-march=icelake-client')
       'x86simdsort-icl.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=icelake-client', openmpflags],
+    cpp_args : ['-march=icelake-client'],
     gnu_symbol_visibility : 'inlineshidden',
+    dependencies: [omp_dep],
     )
 endif
 
@@ -45,8 +42,9 @@ if cancompilefp16
       'x86simdsort-spr.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=sapphirerapids', openmpflags],
+    cpp_args : ['-march=sapphirerapids'],
     gnu_symbol_visibility : 'inlineshidden',
+    dependencies: [omp_dep],
     )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,14 @@ if get_option('build_vqsortbench')
   benchvq = true
 endif
 
+# openMP:
+omp = []
+omp_dep = []
+if get_option('use_openmp')
+  omp = dependency('openmp', required : true)
+  omp_dep = declare_dependency(dependencies: omp, compile_args: ['-DXSS_USE_OPENMP'])
+endif
+
 fp16code = '''#include<immintrin.h>
 int main() {
   __m512h temp = _mm512_set1_ph(1.0f);
@@ -43,8 +51,8 @@ if get_option('lib_type') == 'shared'
   libsimdsort = shared_library('x86simdsortcpp',
                              'lib/x86simdsort.cpp',
                              include_directories : [src, utils, lib],
-                             link_args : [openmpflags],
                              link_with : [libtargets],
+                             dependencies: [omp_dep],
                              gnu_symbol_visibility : 'inlineshidden',
                              install : true,
                              soversion : 1,
@@ -53,8 +61,8 @@ else
   libsimdsort = static_library('x86simdsortcpp',
                              'lib/x86simdsort.cpp',
                              include_directories : [src, utils, lib],
-                             link_args : [openmpflags],
                              link_with : [libtargets],
+                             dependencies: [omp_dep],
                              gnu_symbol_visibility : 'inlineshidden',
                              install : true,
                              pic: true,

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('x86-simd-sort', 'cpp',
-        version : '6.0.x',
+        version : '7.0.x',
         license : 'BSD 3-clause',
         default_options : ['cpp_std=c++17'])
 fs = import('fs')
@@ -71,7 +71,7 @@ endif
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(libraries : libsimdsort,
-                 version : '4.0',
+                 version : '7.0',
                  name : 'libx86simdsortcpp',
                  filebase : 'x86simdsortcpp',
                  description : 'C++ template library for high performance SIMD based sorting routines.')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,9 +1,5 @@
 libtests = []
 
-if get_option('use_openmp')
-  openmpflags = ['-DXSS_USE_OPENMP=true']
-endif
-
 # Add compile flags when needed for the ASAN CI run
 testargs = []
 if get_option('asan_ci_dont_validate')
@@ -16,21 +12,21 @@ endif
 
 libtests += static_library('tests_qsort',
   files('test-qsort.cpp', ),
-  dependencies: gtest_dep,
+  dependencies: [omp_dep, gtest_dep],
   include_directories : [src, lib, utils],
-  cpp_args : [testargs, openmpflags],
+  cpp_args : [testargs],
   )
 
 libtests += static_library('tests_kvsort',
   files('test-keyvalue.cpp', ),
-  dependencies: gtest_dep,
+  dependencies: [omp_dep, gtest_dep],
   include_directories : [src, lib, utils],
-  cpp_args : [testargs, openmpflags],
+  cpp_args : [testargs],
   )
 
 libtests += static_library('tests_objsort',
   files('test-objqsort.cpp', ),
-  dependencies: gtest_dep,
+  dependencies: [omp_dep, gtest_dep],
   include_directories : [src, lib, utils],
-  cpp_args : [testargs, openmpflags],
+  cpp_args : [testargs],
   )


### PR DESCRIPTION
Refactor the build system to improve OpenMP support and updates the project version. The most significant changes include replacing manual OpenMP flag handling with Meson's `dependency` mechanism, updating the project version to `7.0.x`, and ensuring consistent dependency declarations across the build files.

### Build system improvements:

* Replaced manual OpenMP flag handling (`openmpflags`) with Meson's `dependency('openmp')` and `declare_dependency` mechanism. This change centralizes OpenMP configuration and simplifies its usage throughout the build files. (`meson.build`, `lib/meson.build`, `tests/meson.build`) [[1]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4R32-R39) [[2]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L3-R11) [[3]](diffhunk://#diff-b50c9cddf85bce297315124a5760fb7a5995d443f2b1493c6bd84f78141c3a01L3-L6)
* Updated all library and test targets to use the new `omp_dep` dependency instead of manually appending OpenMP flags. (`meson.build`, `lib/meson.build`, `tests/meson.build`) [[1]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L46-R55) [[2]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L56-R65) [[3]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L26-R23) [[4]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L37-R35) [[5]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L48-R47) [[6]](diffhunk://#diff-b50c9cddf85bce297315124a5760fb7a5995d443f2b1493c6bd84f78141c3a01L19-R31)

### Version updates:

* Updated the project version from `6.0.x` to `7.0.x` to reflect significant changes in the build system. (`meson.build`)
* Updated the `pkgconfig` version from `4.0` to `7.0` to align with the new project version. (`meson.build`)