### PR TITLE
Mark partial_qsort<_Float16> as maybe_unused

### DIFF
--- a/src/x86simdsort-static-incl.h
+++ b/src/x86simdsort-static-incl.h
@@ -190,6 +190,7 @@ void x86simdsortStatic::qselect<_Float16>(
     avx512_qselect_fp16((uint16_t *)arr, k, size, hasnan, descending);
 }
 template <>
+[[maybe_unused]]
 void x86simdsortStatic::partial_qsort<_Float16>(
         _Float16 *arr, size_t k, size_t size, bool hasnan, bool descending)
 {


### PR DESCRIPTION
NumPy doesn't need this function and caused a CI failure:

```
In file included from ../numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp:4:
../numpy/_core/src/npysort/x86-simd-sort/src/x86simdsort-static-incl.h:193:6: error: ‘void x86simdsortStatic::partial_qsort(T*, size_t, size_t, bool, bool) [with T = _Float16]’ defined but not used [-Werror=unused-function]
  193 | void x86simdsortStatic::partial_qsort<_Float16>(
```