### PR TITLE
Add MSVC build support on windows

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -6,7 +6,7 @@ if cpp.has_argument('-march=haswell')
       'x86simdsort-avx2.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=haswell'],
+    cpp_args : meson.get_compiler('cpp').get_id() == 'msvc' ? ['/arch:AVX2'] : ['-march=haswell'],
     gnu_symbol_visibility : 'inlineshidden',
     dependencies: [omp_dep],
     )
@@ -18,7 +18,7 @@ if cpp.has_argument('-march=skylake-avx512')
       'x86simdsort-skx.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=skylake-avx512'],
+    cpp_args : meson.get_compiler('cpp').get_id() == 'msvc' ? ['/arch:AVX512'] : ['-march=skylake-avx512'],
     gnu_symbol_visibility : 'inlineshidden',
     dependencies: [omp_dep],
     )
@@ -30,7 +30,7 @@ if cpp.has_argument('-march=icelake-client')
       'x86simdsort-icl.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=icelake-client'],
+    cpp_args : meson.get_compiler('cpp').get_id() == 'msvc' ? ['/arch:AVX512'] : ['-march=icelake-client'],
     gnu_symbol_visibility : 'inlineshidden',
     dependencies: [omp_dep],
     )
@@ -42,7 +42,7 @@ if cancompilefp16
       'x86simdsort-spr.cpp',
       ),
     include_directories : [src],
-    cpp_args : ['-march=sapphirerapids'],
+    cpp_args : meson.get_compiler('cpp').get_id() == 'msvc' ? ['/arch:AVX512'] : ['-march=sapphirerapids'],
     gnu_symbol_visibility : 'inlineshidden',
     dependencies: [omp_dep],
     )

--- a/lib/x86simdsort.cpp
+++ b/lib/x86simdsort.cpp
@@ -1,6 +1,12 @@
+#if defined(_MSC_VER)
+#define XSS_ATTRIBUTE_CONSTRUCTOR
+#else
+#define XSS_ATTRIBUTE_CONSTRUCTOR __attribute__((constructor))
+#endif
 #include "x86simdsort.h"
 #include "x86simdsort-internal.h"
 #include "x86simdsort-scalar.h"
+#include "x86simdsortcpuid.h"
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -12,23 +18,19 @@ static int check_cpu_feature_support(std::string_view cpufeature)
     if ((cpufeature == "avx512_spr") && (!disable_avx512))
 #if defined(__FLT16_MAX__) && !defined(__INTEL_LLVM_COMPILER) \
         && (!defined(__clang_major__) || __clang_major__ >= 18)
-        return __builtin_cpu_supports("avx512f")
-                && __builtin_cpu_supports("avx512fp16")
-                && __builtin_cpu_supports("avx512vbmi2");
+        return xss_cpu_supports("avx512f") && xss_cpu_supports("avx512fp16")
+                && xss_cpu_supports("avx512vbmi2");
 #else
         return 0;
 #endif
     else if ((cpufeature == "avx512_icl") && (!disable_avx512))
-        return __builtin_cpu_supports("avx512f")
-                && __builtin_cpu_supports("avx512vbmi2")
-                && __builtin_cpu_supports("avx512bw")
-                && __builtin_cpu_supports("avx512vl");
+        return xss_cpu_supports("avx512f") && xss_cpu_supports("avx512vbmi2")
+                && xss_cpu_supports("avx512bw") && xss_cpu_supports("avx512vl");
     else if ((cpufeature == "avx512_skx") && (!disable_avx512))
-        return __builtin_cpu_supports("avx512f")
-                && __builtin_cpu_supports("avx512dq")
-                && __builtin_cpu_supports("avx512vl");
+        return xss_cpu_supports("avx512f") && xss_cpu_supports("avx512dq")
+                && xss_cpu_supports("avx512vl");
     else if (cpufeature == "avx2")
-        return __builtin_cpu_supports("avx2");
+        return xss_cpu_supports("avx2");
 
     return 0;
 }
@@ -121,11 +123,11 @@ constexpr bool IS_TYPE_FLOAT16()
 
 /* runtime dispatch mechanism */
 #define DISPATCH(func, TYPE, ISA) \
-    DECLARE_INTERNAL_##func(TYPE) static __attribute__((constructor)) void \
-    CAT(CAT(resolve_, func), TYPE)(void) \
+    DECLARE_INTERNAL_##func(TYPE) static XSS_ATTRIBUTE_CONSTRUCTOR void CAT( \
+            CAT(resolve_, func), TYPE)(void) \
     { \
         CAT(CAT(internal_, func), TYPE) = &xss::scalar::func<TYPE>; \
-        __builtin_cpu_init(); \
+        xss_cpu_init(); \
         std::string_view preferred_cpu = find_preferred_cpu(ISA); \
         if constexpr (dispatch_requested("avx512", ISA)) { \
             if (preferred_cpu.find("avx512") != std::string_view::npos) { \
@@ -248,12 +250,12 @@ DISPATCH_ALL(argselect,
     }
 
 #define DISPATCH_KV_FUNC(func, TYPE1, TYPE2, ISA) \
-    static __attribute__((constructor)) void CAT( \
+    static XSS_ATTRIBUTE_CONSTRUCTOR void CAT( \
             CAT(CAT(CAT(resolve_, func), _), TYPE1), TYPE2)(void) \
     { \
         CAT(CAT(CAT(CAT(internal_, func), _), TYPE1), TYPE2) \
                 = &xss::scalar::func<TYPE1, TYPE2>; \
-        __builtin_cpu_init(); \
+        xss_cpu_init(); \
         std::string_view preferred_cpu = find_preferred_cpu(ISA); \
         if constexpr (dispatch_requested("avx512", ISA)) { \
             if (preferred_cpu.find("avx512") != std::string_view::npos) { \

--- a/lib/x86simdsort.h
+++ b/lib/x86simdsort.h
@@ -6,8 +6,13 @@
 #include <functional>
 #include <numeric>
 
+#if defined(_MSC_VER)
+#define XSS_EXPORT_SYMBOL __declspec(dllexport)
+#define XSS_HIDE_SYMBOL
+#else
 #define XSS_EXPORT_SYMBOL __attribute__((visibility("default")))
 #define XSS_HIDE_SYMBOL __attribute__((visibility("hidden")))
+#endif
 #define UNUSED(x) (void)(x)
 
 namespace x86simdsort {
@@ -73,11 +78,14 @@ XSS_EXPORT_SYMBOL void keyvalue_partial_sort(T1 *key,
 template <typename T, typename U, typename Func>
 XSS_EXPORT_SYMBOL void object_qsort(T *arr, U arrsize, Func key_func)
 {
-    static_assert(std::is_integral<U>::value, "arrsize must be an integral type");
+    static_assert(std::is_integral<U>::value,
+                  "arrsize must be an integral type");
     static_assert(sizeof(U) == sizeof(int32_t) || sizeof(U) == sizeof(int64_t),
                   "arrsize must be 32 or 64 bits");
-    using return_type_of = typename decltype(std::function{key_func})::result_type;
-    static_assert(sizeof(return_type_of) == sizeof(int32_t) || sizeof(return_type_of) == sizeof(int64_t),
+    using return_type_of =
+            typename decltype(std::function {key_func})::result_type;
+    static_assert(sizeof(return_type_of) == sizeof(int32_t)
+                          || sizeof(return_type_of) == sizeof(int64_t),
                   "key_func return type must be 32 or 64 bits");
     std::vector<return_type_of> keys(arrsize);
     for (U ii = 0; ii < arrsize; ++ii) {

--- a/lib/x86simdsortcpuid.h
+++ b/lib/x86simdsortcpuid.h
@@ -1,0 +1,48 @@
+#ifndef X86SIMDSORT_CPUID_H
+#define X86SIMDSORT_CPUID_H
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#include <string>
+#include <unordered_map>
+
+static std::unordered_map<std::string, bool> xss_cpu_features;
+
+inline void xss_cpu_init()
+{
+    int cpuInfo[4] = {0};
+    // Check AVX2
+    __cpuid(cpuInfo, 0);
+    int nIds = cpuInfo[0];
+    __cpuid(cpuInfo, 1);
+    bool osxsave = (cpuInfo[2] & (1 << 27)) != 0;
+    bool avx = (cpuInfo[2] & (1 << 28)) != 0;
+    __cpuid(cpuInfo, 7);
+    bool avx2 = (cpuInfo[1] & (1 << 5)) != 0;
+    bool avx512f = (cpuInfo[1] & (1 << 16)) != 0;
+    bool avx512dq = (cpuInfo[1] & (1 << 17)) != 0;
+    bool avx512bw = (cpuInfo[1] & (1 << 30)) != 0;
+    bool avx512vl = (cpuInfo[1] & (1 << 31)) != 0;
+    bool avx512vbmi2 = (cpuInfo[2] & (1 << 6)) != 0;
+    bool avx512fp16 = (cpuInfo[3] & (1 << 23)) != 0;
+    // Store results
+    xss_cpu_features["avx2"] = avx2;
+    xss_cpu_features["avx512f"] = avx512f;
+    xss_cpu_features["avx512dq"] = avx512dq;
+    xss_cpu_features["avx512bw"] = avx512bw;
+    xss_cpu_features["avx512vl"] = avx512vl;
+    xss_cpu_features["avx512vbmi2"] = avx512vbmi2;
+    xss_cpu_features["avx512fp16"] = avx512fp16;
+}
+
+inline bool xss_cpu_supports(const char *feature)
+{
+    auto it = xss_cpu_features.find(feature);
+    return it != xss_cpu_features.end() && it->second;
+}
+
+#else
+#define xss_cpu_init() __builtin_cpu_init()
+#define xss_cpu_supports(feature) __builtin_cpu_supports(feature)
+#endif // _MSC_VER
+#endif // X86SIMDSORT_CPUID_H

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,4 @@
+
 project('x86-simd-sort', 'cpp',
         version : '7.0.x',
         license : 'BSD 3-clause',


### PR DESCRIPTION
This pull request improves cross-platform compatibility for CPU feature detection and compiler flags in the `x86simdsort` library. The main changes ensure that both MSVC (Windows) and non-MSVC (Linux/macOS) toolchains are supported for SIMD-specific compilation and runtime CPU feature detection. Additionally, some code style and macro improvements were made for clarity and maintainability.

**Build system and cross-platform compatibility:**

* Updated `lib/meson.build` to use MSVC-specific compiler flags (`/arch:AVX2` and `/arch:AVX512`) when building with MSVC, instead of the GCC/Clang flags (`-march=...`). This change ensures correct SIMD instruction set targeting on Windows. [[1]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L9-R9) [[2]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L21-R21) [[3]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L33-R33) [[4]](diffhunk://#diff-f95a8510ab53a5e21d9e4a306b12f76fc79086143aa8989c13effed889bec144L45-R45)

**CPU feature detection abstraction:**

* Added a new header `lib/x86simdsortcpuid.h` that abstracts CPU feature detection for both MSVC and non-MSVC compilers. For MSVC, it uses intrinsics and caches feature results; for others, it falls back to built-in functions. All runtime feature checks in the code now use this abstraction. [[1]](diffhunk://#diff-7497e64959e82fd6146ce8392d60c9aedf2a000290141afc05500b7e9084336dR1-R48) [[2]](diffhunk://#diff-662a93cc277590edf3d381dce21de190a27b44092043a686824025f6403b994cR1-R9) [[3]](diffhunk://#diff-662a93cc277590edf3d381dce21de190a27b44092043a686824025f6403b994cL15-R33)

**Macro and symbol visibility improvements:**

* Introduced new macros (`XSS_ATTRIBUTE_CONSTRUCTOR`, `XSS_EXPORT_SYMBOL`, `XSS_HIDE_SYMBOL`) to handle constructor attributes and symbol visibility in a cross-platform way, improving support for MSVC and other compilers. [[1]](diffhunk://#diff-662a93cc277590edf3d381dce21de190a27b44092043a686824025f6403b994cR1-R9) [[2]](diffhunk://#diff-662a93cc277590edf3d381dce21de190a27b44092043a686824025f6403b994cL124-R130) [[3]](diffhunk://#diff-662a93cc277590edf3d381dce21de190a27b44092043a686824025f6403b994cL251-R258) [[4]](diffhunk://#diff-c0fd758293df0b249624da16a34a473568b87fc50c8ae4ad0bf1fe158e622a99R9-R15)

**Code style and static assertions:**

* Improved code style and static assertions in `object_qsort` for better readability and error messages.

**Project file update:**

* Added a missing newline to the top of `meson.build` for style consistency.