### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/avx2-32bit-half.hpp
+++ b/src/avx2-32bit-half.hpp
@@ -42,11 +42,11 @@ struct avx2_half_vector<int32_t> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_half(mask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_half(intMask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(intMask));
     }
     static regi_t seti(int v1, int v2, int v3, int v4)
     {
@@ -209,11 +209,11 @@ struct avx2_half_vector<uint32_t> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_half(mask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_half(intMask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(intMask));
     }
     static regi_t seti(int v1, int v2, int v3, int v4)
     {
@@ -387,11 +387,11 @@ struct avx2_half_vector<float> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_half(mask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_half(intMask);
+        return convert_int_to_avx2_mask_half(static_cast<int32_t>(intMask));
     }
     static int32_t convert_mask_to_int(opmask_t mask)
     {

--- a/src/avx2-64bit-qsort.hpp
+++ b/src/avx2-64bit-qsort.hpp
@@ -53,11 +53,11 @@ struct avx2_vector<int64_t> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_64bit(mask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_64bit(intMask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(intMask));
     }
     static ymmi_t seti(int64_t v1, int64_t v2, int64_t v3, int64_t v4)
     {
@@ -241,11 +241,11 @@ struct avx2_vector<uint64_t> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_64bit(mask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_64bit(intMask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(intMask));
     }
     static ymmi_t seti(int64_t v1, int64_t v2, int64_t v3, int64_t v4)
     {
@@ -439,11 +439,11 @@ struct avx2_vector<double> {
     static opmask_t get_partial_loadmask(uint64_t num_to_read)
     {
         auto mask = ((0x1ull << num_to_read) - 0x1ull);
-        return convert_int_to_avx2_mask_64bit(mask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(mask));
     }
     static opmask_t convert_int_to_mask(uint64_t intMask)
     {
-        return convert_int_to_avx2_mask_64bit(intMask);
+        return convert_int_to_avx2_mask_64bit(static_cast<int32_t>(intMask));
     }
     static int32_t convert_mask_to_int(opmask_t mask)
     {

--- a/src/avx2-emu-funcs.hpp
+++ b/src/avx2-emu-funcs.hpp
@@ -147,7 +147,7 @@ X86_SIMD_SORT_INLINE
 __m256i convert_int_to_avx2_mask(int32_t m)
 {
     return _mm256_loadu_si256(
-            (const __m256i *)avx2_mask_helper_lut32[m].data());
+            (const __m256i *)avx2_mask_helper_lut32[static_cast<size_t>(m)].data());
 }
 
 X86_SIMD_SORT_INLINE
@@ -160,7 +160,7 @@ X86_SIMD_SORT_INLINE
 __m256i convert_int_to_avx2_mask_64bit(int32_t m)
 {
     return _mm256_loadu_si256(
-            (const __m256i *)avx2_mask_helper_lut64[m].data());
+            (const __m256i *)avx2_mask_helper_lut64[static_cast<size_t>(m)].data());
 }
 
 X86_SIMD_SORT_INLINE
@@ -173,7 +173,7 @@ X86_SIMD_SORT_INLINE
 __m128i convert_int_to_avx2_mask_half(int32_t m)
 {
     return _mm_loadu_si128(
-            (const __m128i *)avx2_mask_helper_lut32_half[m].data());
+            (const __m128i *)avx2_mask_helper_lut32_half[static_cast<size_t>(m)].data());
 }
 
 X86_SIMD_SORT_INLINE

--- a/src/avx512-16bit-qsort.hpp
+++ b/src/avx512-16bit-qsort.hpp
@@ -49,10 +49,10 @@ struct zmm_vector<float16> {
 
     static opmask_t ge(reg_t x, reg_t y)
     {
-        reg_t sign_x = _mm512_and_si512(x, _mm512_set1_epi16(0x8000));
-        reg_t sign_y = _mm512_and_si512(y, _mm512_set1_epi16(0x8000));
-        reg_t exp_x = _mm512_and_si512(x, _mm512_set1_epi16(0x7c00));
-        reg_t exp_y = _mm512_and_si512(y, _mm512_set1_epi16(0x7c00));
+        reg_t sign_x = _mm512_and_si512(x, _mm512_set1_epi16(static_cast<short>(0x8000)));
+        reg_t sign_y = _mm512_and_si512(y, _mm512_set1_epi16(static_cast<short>(0x8000)));
+        reg_t exp_x = _mm512_and_si512(x, _mm512_set1_epi16(static_cast<short>(0x7c00)));
+        reg_t exp_y = _mm512_and_si512(y, _mm512_set1_epi16(static_cast<short>(0x7c00)));
         reg_t mant_x = _mm512_and_si512(x, _mm512_set1_epi16(0x3ff));
         reg_t mant_y = _mm512_and_si512(y, _mm512_set1_epi16(0x3ff));
 
@@ -62,7 +62,7 @@ struct zmm_vector<float16> {
         __mmask32 neg = _mm512_mask_cmpeq_epu16_mask(
                 sign_eq,
                 sign_x,
-                _mm512_set1_epi16(0x8000)); // both numbers are -ve
+                _mm512_set1_epi16(static_cast<short>(0x8000))); // both numbers are -ve
 
         // compare exponents only if signs are equal:
         mask_ge = mask_ge
@@ -136,7 +136,7 @@ struct zmm_vector<float16> {
     static type_t float_to_uint16(float val)
     {
         __m128 xmm = _mm_load_ss(&val);
-        __m128i xmm2 = _mm_cvtps_ph(xmm, _MM_FROUND_NO_EXC);
+        __m128i xmm2 = _mm_cvtps_ph(xmm, 0); // Use 0 (round to nearest) instead of _MM_FROUND_NO_EXC
         return _mm_extract_epi16(xmm2, 0);
     }
     static type_t reducemax(reg_t v)

--- a/src/xss-common-keyvaluesort.hpp
+++ b/src/xss-common-keyvaluesort.hpp
@@ -588,7 +588,7 @@ X86_SIMD_SORT_INLINE void xss_qsort_kv(
     int maxiters = -1;
     bool minarrsize = true;
 #else
-    int maxiters = 2 * log2(arrsize);
+    int maxiters = static_cast<int>(2 * log2(arrsize));
     bool minarrsize = arrsize > 1 ? true : false;
 #endif // XSS_TEST_KEYVALUE_BASE_CASE
 
@@ -683,7 +683,7 @@ X86_SIMD_SORT_INLINE void xss_select_kv(T1 *keys,
     int maxiters = -1;
     bool minarrsize = true;
 #else
-    int maxiters = 2 * log2(arrsize);
+    int maxiters = static_cast<int>(2 * log2(arrsize));
     bool minarrsize = arrsize > 1 ? true : false;
 #endif // XSS_TEST_KEYVALUE_BASE_CASE
 


### PR DESCRIPTION
This pull request fixes MSVC compiler warnings by adding appropriate casts in the following areas:

1. Added  for array index conversions in avx2-emu-funcs.hpp
2. Added  for 16-bit constants like 0x8000 and 0x7c00 in avx512-16bit-qsort.hpp
3. Replaced  with 0 for the  intrinsic to fix out of range warning
4. Added  when passing uint64_t values to functions expecting int32_t
5. Added  for double to int conversions in xss-common-keyvaluesort.hpp

These changes resolve MSVC compiler warnings C4244 (conversion with potential data loss), C4309 (truncation of constant value), and C4556 (value of intrinsic immediate argument out of range).

Note: The warnings about 'getenv' being unsafe were intentionally not addressed as it would require platform-specific handling.